### PR TITLE
Add a hashivault_list command.

### DIFF
--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+DOCUMENTATION = '''
+---
+module: hashivault_list
+version_added: "0.1"
+short_description: Hashicorp Vault list
+description:
+    - The M(hashivault_list) module lists keys in Hashicorp Vault.  By
+      default this will list top-level keys under C(/secret), but you
+      can provide an alternate location as I(secret).  This includes both
+      immediate subkeys and subkey paths, like the C(vault list) command.
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    verify:
+        description:
+            - verify TLS certificate
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - authentication type to use: token, userpass, github, ldap
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: False
+    password:
+        description:
+            - password to login to vault.
+        default: False
+    secret:
+        description:
+            - secret path to list.  If this does not begin with a C(/)
+              then it is interpreted as a subpath of C(/secret).  This
+              is always interpreted as a "directory": if a key C(/secret/foo)
+              exists, and you pass C(/secret/foo) as I(secret), then the key
+              itself will not be returned, but subpaths like
+              C(/secret/foo/bar) will.
+        default: ''
+'''
+RETURN = '''
+---
+secrets:
+    description: list of secrets found, if any
+    returned: success
+    type: list
+    sample: ["giant", "stalks/"]
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_list:
+        secret: 'giant'
+      register: 'fie'
+    - debug: msg="Known secrets are {{ fie.secrets|join(', ') }}"
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['secret'] = dict(default='', type='str')
+    module = hashivault_init(argspec)
+    result = hashivault_list(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.hashivault import *
+
+
+@hashiwrapper
+def hashivault_list(params):
+    result = {"changed": False, "rc": 0}
+    client = hashivault_auth_client(params)
+    secret = params.get('secret')
+    if secret.startswith('/'):
+        secret = secret.lstrip('/')
+    else:
+        secret = 'secret/' + secret
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        response = client.list(secret)
+        if not response:
+            response = {}
+        result['secrets'] = response.get('data', {}).get('keys', [])
+    return result
+
+
+if __name__ == '__main__':
+    main()

--- a/functional/test.yml
+++ b/functional/test.yml
@@ -21,6 +21,33 @@
     - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/giant written'" }
     - assert: { that: "{{vault_write.rc}} == 0" }
 
+    - hashivault_write:
+        secret: stalks/bean
+        data:
+          height: tall
+      register: vault_write
+    - assert: { that: vault_write.rc == 0 }
+
+    - hashivault_list: {}
+      register: vault_list
+    - assert: { that: "vault_list.rc == 0" }
+    - assert: { that: "'giant' in vault_list.secrets" }
+    - assert: { that: "'stalks/' in vault_list.secrets" }
+
+    # This reads the secrets _underneath_ /secret/giant, e.g.,
+    # /secret/giant/color.  If none have been written returns empty.
+    - hashivault_list:
+        secret: 'giant'
+      register: vault_list
+    - assert: { that: "vault_list.rc == 0" }
+    - assert: { that: "vault_list.secrets|length == 0" }
+
+    - hashivault_list:
+        secret: stalks
+      register: vault_list
+    - assert: { that: vault_list.rc == 0 }
+    - assert: { that: "'bean' in vault_list.secrets" }
+
     - hashivault_read:
         secret: 'giant'
         key: 'fie'


### PR DESCRIPTION
This adds a `hashivault_list` command, replicating the `vault list` command-line request.

This is parallel to the other `hashivault_*_list` commands that already exist.  In my particular case, I want to keep a "directory" of related credentials in Vault and iterate through them.