### PR TITLE
Disabling logging of token and password as these are sensitive info

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -11,9 +11,9 @@ def hashivault_argspec():
         url = dict(required=False, default=os.environ.get('VAULT_ADDR', ''), type='str'),
         verify = dict(required=False, default=(not os.environ.get('VAULT_SKIP_VERIFY', '')), type='bool'),
         authtype = dict(required=False, default='token', type='str'),
-        token = dict(required=False, default=os.environ.get('VAULT_TOKEN', ''), type='str'),
+        token = dict(required=False, default=os.environ.get('VAULT_TOKEN', ''), type='str', no_log=True),
         username = dict(required=False, type='str'),
-        password = dict(required=False, type='str')
+        password = dict(required=False, type='str',no_log=True)
     )
     return argument_spec
 


### PR DESCRIPTION
Hi,

Ansible has a way to hide passwords/sensitive values which are used as args for modules. I've set the token and password as such. This way they will not display value but a place-holder when you use high verbosity.

For example:
```
            "token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
```