### PR TITLE
Return Vault data when writing to secret

### DIFF
--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -91,10 +91,12 @@ def hashivault_write(params):
             else:
                 write_data  = {}
             write_data.update(data)
-            client.write((secret), **write_data)
+            returned_data = client.write((secret), **write_data)
+            result['data'] = returned_data
             result['msg'] = "Secret %s updated" % secret
         else:
-            client.write((secret), **data)
+            returned_data = client.write((secret), **data)
+            result['data'] = returned_data
             result['msg'] = "Secret %s written" % secret
     result['changed'] = True
     return result


### PR DESCRIPTION
Some backends ( like PKI ) return data when writing to them ( like PKI issue ) 

Fixes Issue #6 

This patch exposes that data as : 
```{
    "changed": true, 
    "data": {
        "auth": null, 
        "data": {
            "certificate": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----", 
            "issuing_ca": "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----", 
            "private_key": "-----BEGIN RSA PRIVATE KEY-----\n-----END RSA PRIVATE KEY-----", 
            "private_key_type": "rsa", 
            "serial_number": "24:f4:za:44:ba:50:a8:97:7e:32:5"
        }, 
        "lease_duration": 2764799, 
        "lease_id": "pki/issue/example/0bef285", 
        "renewable": false, 
        "request_id": "fbec62e2-ccd5-d24", 
        "warnings": null, 
        "wrap_info": null
    }, 
    "msg": "Secret pki/issue/example written", 
    "rc": 0
}```