### PR TITLE
quoted all lines in modules' documentation with colons so ansible-doc

### DIFF
--- a/ansible/modules/hashivault/hashivault_audit_enable.py
+++ b/ansible/modules/hashivault/hashivault_audit_enable.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_audit_list.py
+++ b/ansible/modules/hashivault/hashivault_audit_list.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_auth_enable.py
+++ b/ansible/modules/hashivault/hashivault_auth_enable.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_auth_list.py
+++ b/ansible/modules/hashivault/hashivault_auth_list.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_init.py
+++ b/ansible/modules/hashivault/hashivault_init.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -20,7 +20,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:
@@ -36,12 +36,12 @@ options:
         default: False
     secret:
         description:
-            - secret path to list.  If this does not begin with a C(/)
+            - 'secret path to list.  If this does not begin with a C(/)
               then it is interpreted as a subpath of C(/secret).  This
               is always interpreted as a "directory": if a key C(/secret/foo)
               exists, and you pass C(/secret/foo) as I(secret), then the key
               itself will not be returned, but subpaths like
-              C(/secret/foo/bar) will.
+              C(/secret/foo/bar) will.'
         default: ''
 '''
 RETURN = '''

--- a/ansible/modules/hashivault/hashivault_policy_delete.py
+++ b/ansible/modules/hashivault/hashivault_policy_delete.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_policy_get.py
+++ b/ansible/modules/hashivault/hashivault_policy_get.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_policy_list.py
+++ b/ansible/modules/hashivault/hashivault_policy_list.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_policy_set.py
+++ b/ansible/modules/hashivault/hashivault_policy_set.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_seal.py
+++ b/ansible/modules/hashivault/hashivault_seal.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_secret_disable.py
+++ b/ansible/modules/hashivault/hashivault_secret_disable.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_secret_enable.py
+++ b/ansible/modules/hashivault/hashivault_secret_enable.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_secret_list.py
+++ b/ansible/modules/hashivault/hashivault_secret_list.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_status.py
+++ b/ansible/modules/hashivault/hashivault_status.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_unseal.py
+++ b/ansible/modules/hashivault/hashivault_unseal.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_userpass_create.py
+++ b/ansible/modules/hashivault/hashivault_userpass_create.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_userpass_delete.py
+++ b/ansible/modules/hashivault/hashivault_userpass_delete.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -17,7 +17,7 @@ options:
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:
-            - authentication type to use: token, userpass, github, ldap
+            - "authentication type to use: token, userpass, github, ldap"
         default: token
     token:
         description:


### PR DESCRIPTION
quoted all lines in modules' documentation with colons so ansible-doc would parse them correctly.
It appears that ansible/ansible-doc is pickier about colons than most YAML parsers are.