### PR TITLE
Added the ability to set shares and threshold on init

### DIFF
--- a/functional/run.sh
+++ b/functional/run.sh
@@ -5,10 +5,11 @@
 #VAULT_TOKEN=da20ff3b-3b56-82f9-19bb-56be55b77c92
 #VAULT_KEYS=DsGodBlDavvj4GSKO7HlD5RqVYuywBFWdGGziAOyPi8=
 #
-# For now run the init test manually since this currently does
+# For now run the init tests manually since this currently does
 # not capture the keys for later use
 #
 #ansible-playbook -v test_init.yml
+#ansible-playbook -v test_init_config.yml
 ansible-playbook -v test.yml
 ansible-playbook -v test_auth.yml
 ansible-playbook -v test_policy.yml

--- a/functional/test_init_config.yml
+++ b/functional/test_init_config.yml
@@ -1,0 +1,16 @@
+---
+- hosts: localhost
+  tasks:
+    - hashivault_init:
+        secret_shares: 6
+        secret_threshold: 2
+      register: 'vault_init'
+    - block:
+      - assert: { that: "{{vault_init.rc}} == 0" }
+      when: "vault_init.changed == False"
+    - block:
+      - assert: { that: "'keys' in vault_init" }
+      - assert: { that: "'root_token' in vault_init" }
+      - assert: { that: "{{vault_init.rc}} == 0" }
+      - assert: { that: "vault_init['keys'] | length == 6" }
+      when: "vault_init.changed == True"


### PR DESCRIPTION
In some use cases the standard 5/3 secret share may not be desired, on initialization you are now able to set your secret sharing distribution