### PR TITLE
Avoid unneeded changes when possible

### DIFF
--- a/ansible/modules/hashivault/hashivault_audit_enable.py
+++ b/ansible/modules/hashivault/hashivault_audit_enable.py
@@ -71,8 +71,12 @@ def hashivault_audit_enable(params):
     name = params.get('name')
     description = params.get('description')
     options = params.get('options')
+    backends = client.list_audit_backends()
+    path = name + "/"
+    if path in backends and backends[path]["options"] == options:
+        return {'changed': False}
     client.enable_audit_backend(name, description=description, options=options)
-    return {'changed': True}
+    return {'changed': True }
 
 
 if __name__ == '__main__':

--- a/ansible/modules/hashivault/hashivault_auth_enable.py
+++ b/ansible/modules/hashivault/hashivault_auth_enable.py
@@ -66,6 +66,10 @@ def hashivault_auth_enable(params):
     client = hashivault_auth_client(params)
     name = params.get('name')
     description = params.get('description')
+    backends = client.list_auth_backends()
+    path = name + "/"
+    if path in backends:
+        return {'changed': False}
     client.enable_auth_backend(name, description=description)
     return {'changed': True}
 

--- a/ansible/modules/hashivault/hashivault_policy_delete.py
+++ b/ansible/modules/hashivault/hashivault_policy_delete.py
@@ -63,6 +63,8 @@ from ansible.module_utils.hashivault import *
 def hashivault_policy_delete(params):
     name = params.get('name')
     client = hashivault_auth_client(params)
+    if name not in client.list_policies():
+        return {'changed': False}
     client.delete_policy(name)
     return {'changed': True}
 

--- a/ansible/modules/hashivault/hashivault_policy_set.py
+++ b/ansible/modules/hashivault/hashivault_policy_set.py
@@ -63,6 +63,9 @@ def hashivault_policy_set(params):
     client = hashivault_auth_client(params)
     name = params.get('name')
     rules = params.get('rules')
+    current = client.get_policy(name)
+    if current == rules:
+        return {'changed': False}
     client.set_policy(name, rules)
     return {'changed': True}
 

--- a/ansible/modules/hashivault/hashivault_secret_enable.py
+++ b/ansible/modules/hashivault/hashivault_secret_enable.py
@@ -77,6 +77,10 @@ def hashivault_secret_enable(params):
     backend = params.get('backend')
     description = params.get('description')
     config = params.get('config')
+    secrets = client.list_secret_backends()
+    path = name + "/"
+    if path in secrets:
+        return {'changed': False}
     client.enable_secret_backend(backend, description=description, mount_point=name, config=config)
     return {'changed': True}
 

--- a/functional/test_audit.yml
+++ b/functional/test_audit.yml
@@ -4,24 +4,19 @@
   tasks:
     - hashivault_audit_list:
       register: 'vault_audit_list'
-    - block:
-      - hashivault_audit_enable:
-          name: "file"
-          options:
-            file_path: "/tmp/audit.log"
-        failed_when: False
-        register: 'vault_audit_enable'
-      - assert: { that: "{{vault_audit_enable.changed}} == False" }
-      - assert: { that: "{{vault_audit_enable.failed}} == False" }
-      - assert: { that: "'{{vault_audit_enable.msg}}' == 'Exception: path already in use'" }
-      - assert: { that: "{{vault_audit_enable.rc}} == 1" }
-      when: "'file/' in vault_audit_list.backends"
-    - block:
-      - hashivault_audit_enable:
-          name: "file"
-          options:
-            file_path: "/tmp/audit.log"
-        register: 'vault_audit_enable'
-      - assert: { that: "{{vault_audit_enable.changed}} == True" }
-      - assert: { that: "{{vault_audit_enable.rc}} == 0" }
-      when: "'file/' not in vault_audit_list.backends"
+
+    - hashivault_audit_enable:
+        name: "file"
+        options:
+          file_path: "/tmp/vault.log"
+      register: 'vault_audit_enable'
+    - assert: { that: "{{vault_audit_enable.changed}} == True" }
+    - assert: { that: "{{vault_audit_enable.rc}} == 0" }
+
+    - hashivault_audit_enable:
+        name: "file"
+        options:
+          file_path: "/tmp/vault.log"
+      register: 'vault_audit_enable_twice'
+    - assert: { that: "{{vault_audit_enable_twice.changed}} == False" }
+    - assert: { that: "{{vault_audit_enable_twice.rc}} == 0" }

--- a/functional/test_auth.yml
+++ b/functional/test_auth.yml
@@ -24,3 +24,9 @@
       - assert: { that: "{{vault_auth_enable.changed}} == True" }
       - assert: { that: "{{vault_auth_enable.rc}} == 0" }
       when: "'userpass/' not in vault_auth_list.backends"
+    - block:
+      - hashivault_auth_enable:
+          name: "userpass"
+        register: 'vault_auth_enable_twice'
+      - assert: { that: "{{vault_auth_enable_twice.changed}} == False" }
+      - assert: { that: "{{vault_auth_enable_twice.rc}} == 0" }

--- a/functional/test_policy.yml
+++ b/functional/test_policy.yml
@@ -20,6 +20,14 @@
     - assert: { that: "{{vault_policy_set.changed}} == True" }
     - assert: { that: "{{vault_policy_set.rc}} == 0" }
 
+    - name: Set policy again and check that it doesn't change
+      hashivault_policy_set:
+        name: "{{namespace}}"
+        rules: "{{rules}}"
+      register: 'vault_policy_set_twice'
+    - assert: { that: "{{vault_policy_set_twice.changed}} == False" }
+    - assert: { that: "{{vault_policy_set_twice.rc}} == 0" }
+
     - name: Get policy and make sure it set properly
       hashivault_policy_get:
         name: '{{namespace}}'

--- a/functional/test_policy.yml
+++ b/functional/test_policy.yml
@@ -12,6 +12,13 @@
         } 
     expected: "{{rules | regex_replace('\n', '')}}"
   tasks:
+    - name: Delete a policy that doesn't exist and check that doesn't change or fail
+      hashivault_policy_delete:
+        name: '{{namespace}}'
+      register: 'vault_policy_delete'
+    - assert: { that: "{{vault_policy_delete.changed}} == False" }
+    - assert: { that: "{{vault_policy_delete.rc}} == 0" }
+
     - name: Set new policy
       hashivault_policy_set:
         name: "{{namespace}}"

--- a/functional/test_rekey.yml
+++ b/functional/test_rekey.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  gather_facts: no
   vars:
     unseal_key:  "{{ lookup('env','VAULT_KEYS') }}"
   tasks:

--- a/functional/test_secret.yml
+++ b/functional/test_secret.yml
@@ -17,6 +17,14 @@
     - assert: { that: "{{vault_secret_enable.changed}} == True" }
     - assert: { that: "{{vault_secret_enable.rc}} == 0" }
 
+    - name: Enable same secret store again and check it doesn't fail
+      hashivault_secret_enable:
+        name: "ephemeral"
+        backend: "generic"
+      register: 'vault_secret_enable_twice'
+    - assert: { that: "{{vault_secret_enable_twice.changed}} == False" }
+    - assert: { that: "{{vault_secret_enable_twice.rc}} == 0" }
+
     - name: Write a value to the ephermal store
       hashivault_write:
         secret: '/ephemeral/name'

--- a/functional/test_secret.yml
+++ b/functional/test_secret.yml
@@ -91,7 +91,6 @@
     - assert: { that: "{{vault_read.changed}} == False" }
     - assert: { that: "'{{vault_read.msg}}' == 'Secret ephemeral/name is not in vault'" }
 
-    - set_fact:
     - name: Disable ephermeral secret store
       hashivault_secret_disable:
         name: "ephemeral"


### PR DESCRIPTION
We are starting to try this library to manage the configuration of vault and we'd like to be able to run the ansible playbook idempotently.

We have found that some tasks fail if the resource already exists (for example enabling secrets), and others run always even if the result is the same (like setting policies).

A workaround we have found is to register the state in variables and use `when`, but sometimes it's very cumbersome, or even impossible in combination with `with_items`.

I wonder if there is any reason to don't try to compare the existing with the desired state.
Find here an initial implementation of the idea for some tasks, mostly for discussion, it's not tested enough to be merged.