### PR TITLE
Added modules for rekey

### DIFF
--- a/ansible/modules/hashivault/hashivault_rekey.py
+++ b/ansible/modules/hashivault/hashivault_rekey.py
@@ -2,7 +2,7 @@
 DOCUMENTATION = '''
 ---
 module: hashivault_rekey
-version_added: "1.3.2"
+version_added: "3.3.0"
 short_description: Hashicorp Vault rekey module
 description:
     - Module to (update) rekey Hashicorp Vault. Requires that a rekey

--- a/ansible/modules/hashivault/hashivault_rekey.py
+++ b/ansible/modules/hashivault/hashivault_rekey.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+DOCUMENTATION = '''
+---
+module: hashivault_rekey
+version_added: "1.3.2"
+short_description: Hashicorp Vault rekey module
+description:
+    - Module to (update) rekey Hashicorp Vault. Requires that a rekey
+      be started with hashivault_rekey_init.
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    verify:
+        description:
+            - verify TLS certificate
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - authentication type to use: token, userpass, github, ldap
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: False
+    password:
+        description:
+            - password to login to vault.
+        default: False
+    key:
+        description:
+            - vault key shard (aka unseal key).
+        default: False
+    nonce:
+        description:
+            - rekey nonce.
+        default: False
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_rekey:
+      key: '{{vault_key}}'
+      nonce: '{{nonce}}'
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['key'] = dict(required=True, type='str')
+    argspec['nonce'] = dict(required=True, type='str')
+    module = hashivault_init(argspec)
+    result = hashivault_rekey(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.hashivault import *
+
+
+@hashiwrapper
+def hashivault_rekey(params):
+    key = params.get('key')
+    nonce = params.get('nonce')
+    client = hashivault_client(params)
+    return {'status': client.rekey(key, nonce), 'changed': True}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_rekey_cancel.py
+++ b/ansible/modules/hashivault/hashivault_rekey_cancel.py
@@ -2,7 +2,7 @@
 DOCUMENTATION = '''
 ---
 module: hashivault_rekey_cancel
-version_added: "1.3.2"
+version_added: "3.3.0"
 short_description: Hashicorp Vault rekey cancel module
 description:
     - Module to cancel rekey Hashicorp Vault.

--- a/ansible/modules/hashivault/hashivault_rekey_cancel.py
+++ b/ansible/modules/hashivault/hashivault_rekey_cancel.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+DOCUMENTATION = '''
+---
+module: hashivault_rekey_cancel
+version_added: "1.3.2"
+short_description: Hashicorp Vault rekey cancel module
+description:
+    - Module to cancel rekey Hashicorp Vault.
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    verify:
+        description:
+            - verify TLS certificate
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: False
+    password:
+        description:
+            - password to login to vault.
+        default: False
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_rekey_cancel:
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    module = hashivault_init(argspec)
+    result = hashivault_rekey_cancel(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.hashivault import *
+
+
+@hashiwrapper
+def hashivault_rekey_cancel(params):
+    client = hashivault_client(params)
+    # Check if rekey is on-going & return when rekey not in progress
+    status = client.rekey_status
+    if not status['started']: 
+        return {'changed': False}
+    return {'status': client.cancel_rekey(), 'changed': True}
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_rekey_init.py
+++ b/ansible/modules/hashivault/hashivault_rekey_init.py
@@ -2,7 +2,7 @@
 DOCUMENTATION = '''
 ---
 module: hashivault_rekey_init
-version_added: "1.3.2"
+version_added: "3.3.0"
 short_description: Hashicorp Vault rekey init module
 description:
     - Module to start rekey Hashicorp Vault.

--- a/ansible/modules/hashivault/hashivault_rekey_init.py
+++ b/ansible/modules/hashivault/hashivault_rekey_init.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python
+DOCUMENTATION = '''
+---
+module: hashivault_rekey_init
+version_added: "1.3.2"
+short_description: Hashicorp Vault rekey init module
+description:
+    - Module to start rekey Hashicorp Vault.
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    verify:
+        description:
+            - verify TLS certificate
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: False
+    password:
+        description:
+            - password to login to vault.
+        default: False
+    secret_shares:
+        description:
+            - specifies the number of shares to split the master key into.
+        default: 5
+    secret_threshold:
+        description:
+            - specifies the number of shares required to reconstruct the master key.
+        default: 3
+    pgp_keys:
+        description:
+            - specifies an array of PGP public keys used to encrypt the output unseal keys.
+        default: []
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_rekey_init:
+        secret_shares: 7
+        secret_threshold: 4
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['secret_shares'] = dict(required=False, type='int', default=5)
+    argspec['secret_threshold'] = dict(required=False, type='int', default=3)
+    argspec['pgp_keys'] = dict(required=False, type='list', default=[])
+    argspec['backup'] = dict(required=False, type='bool', default=False)
+    module = hashivault_init(argspec)
+    result = hashivault_rekey_init(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.hashivault import *
+
+
+@hashiwrapper
+def hashivault_rekey_init(params):
+    client = hashivault_client(params)
+    # Check if rekey is on-going, exit if there is a rekey in progress
+    status = client.rekey_status
+    if status['started']: 
+        return {'changed': False}
+    secret_shares = params.get('secret_shares')
+    secret_threshold = params.get('secret_threshold')
+    pgp_keys = params.get('pgp_keys')
+    backup = params.get('backup')
+    return {'status': client.start_rekey(secret_shares, secret_threshold, pgp_keys, backup), 'changed': True}
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_rekey_status.py
+++ b/ansible/modules/hashivault/hashivault_rekey_status.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+DOCUMENTATION = '''
+---
+module: hashivault_rekey_status
+version_added: "1.3.2"
+short_description: Hashicorp Vault rekey status module
+description:
+    - Module to get rekey status of Hashicorp Vault.
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    verify:
+        description:
+            - verify TLS certificate
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: False
+    password:
+        description:
+            - password to login to vault.
+        default: False
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_rekey_status:
+'''
+
+def main():
+    argspec = hashivault_argspec()
+    module = hashivault_init(argspec)
+    result = hashivault_rekey_status(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.hashivault import *
+
+@hashiwrapper
+def hashivault_rekey_status(params):
+    client = hashivault_client(params)
+    return {'status': client.rekey_status}
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_rekey_status.py
+++ b/ansible/modules/hashivault/hashivault_rekey_status.py
@@ -2,7 +2,7 @@
 DOCUMENTATION = '''
 ---
 module: hashivault_rekey_status
-version_added: "1.3.2"
+version_added: "3.3.0"
 short_description: Hashicorp Vault rekey status module
 description:
     - Module to get rekey status of Hashicorp Vault.

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -13,5 +13,9 @@ ansible-playbook -v test_userpass.yml
 ansible-playbook -v test_secret.yml
 ansible-playbook -v test_complex.yml
 ansible-playbook -v test_unseal.yml
+ansible-playbook -v test_rekey.yml
+# test_rekey.yml changes unseal keys, need to update VAULT_KEYS
+# for further test, if any.
+source ./vaultenv.sh
 
 ./stop.sh

--- a/functional/test_rekey.yml
+++ b/functional/test_rekey.yml
@@ -1,0 +1,67 @@
+---
+- hosts: localhost
+  vars:
+    unseal_key:  "{{ lookup('env','VAULT_KEYS') }}"
+  tasks:
+    # check rekey status
+    - hashivault_rekey_status:
+      register: 'vault_rekey_status'
+    - assert: { that: "{{vault_rekey_status.changed}} == False" }
+    - assert: { that: "{{vault_rekey_status.rc}} == 0" }
+
+    - block:
+        - hashivault_rekey_cancel:
+          register: 'vault_rekey_cancel'
+        - assert: { that: "{{vault_rekey_cancel.changed}} == True" }
+        - assert: { that: "{{vault_rekey_cancel.rc}} == 0" }
+      when: "vault_rekey_status.status.started == True"
+
+    # start rekey 
+    - hashivault_rekey_init:
+        secret_shares: 1
+        secret_threshold: 1
+      register: 'vault_rekey_init'
+    - assert: { that: "{{vault_rekey_init.changed}} == True" }
+    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
+    - assert: { that: "{{vault_rekey_init.status.started}} == True" }
+    - assert: { that: "{{vault_rekey_init.rc}} == 0" }
+
+    # check rekey status
+    - hashivault_rekey_status:
+      register: 'vault_rekey_status'
+    - assert: { that: "{{vault_rekey_status.changed}} == False" }
+    - assert: { that: "{{vault_rekey_status.rc}} == 0" }
+    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
+    - assert: { that: "{{vault_rekey_status.status.started}} == True" }
+
+    # cancel rekey 
+    - block:
+        - hashivault_rekey_cancel:
+          register: 'vault_rekey_cancel'
+        - assert: { that: "{{vault_rekey_cancel.changed}} == True" }
+        - assert: { that: "{{vault_rekey_cancel.rc}} == 0" }
+      when: "vault_rekey_status.status.started == True"
+
+    # (re)start rekey 
+    - hashivault_rekey_init:
+        secret_shares: 1
+        secret_threshold: 1
+      register: 'vault_rekey_init'
+    - assert: { that: "{{vault_rekey_init.changed}} == True" }
+    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
+    - assert: { that: "{{vault_rekey_init.status.started}} == True" }
+    - assert: { that: "{{vault_rekey_init.rc}} == 0" }
+
+    # update rekey
+    - hashivault_rekey:
+        key: "{{ unseal_key }}"
+        nonce: "{{ vault_rekey_init.status.nonce }}"
+      register: 'vault_rekey'
+    - assert: { that: "{{vault_rekey.changed}} == True" }
+    - assert: { that: "{{vault_rekey.rc}} == 0" }
+
+    # update vaultenv.sh with (new) unseal keys after rekey
+    - lineinfile:
+        name: vaultenv.sh
+        regexp: '^export VAULT_KEYS='
+        line: export VAULT_KEYS='{{ vault_rekey['status']['keys'][0] }}'


### PR DESCRIPTION
Vault supports rekey in order to change the number of key-shares, key-thresholds, PGP keys, etc. of a running Vault instance. 

Added the following modules for rekey:
- hashivault_rekey_init: Start new rekey
- hashivault_rekey: Update rekey (by providing current unseal keys)
- hashivault_rekey_cancel: Cancel a rekey in progress
- hashivault_rekey_status: Get status/progress of the on-going rekey