### PR TITLE
Adds support for TLS connections via hvac

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -34,12 +34,12 @@ def hashivault_client(params):
     client_key = params.get('client_key')
     cert = (client_cert, client_key)
     check_verify = params.get('verify')
-    if check_verify == '' or check_verify;
+    if check_verify == '' or check_verify:
         if ca_cert:
             verify = ca_cert
         elif ca_path:
             verify = ca_path
-        else
+        else:
             verify = check_verify
     else:
         verify = check_verify

--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -9,6 +9,10 @@ from ansible.module_utils.basic import AnsibleModule
 def hashivault_argspec():
     argument_spec = dict(
         url = dict(required=False, default=os.environ.get('VAULT_ADDR', ''), type='str'),
+        ca_cert = dict(required=False, default=os.environ.get('VAULT_CACERT', ''), type='str'),
+        ca_path = dict(required=False, default=os.environ.get('VAULT_CAPATH', ''), type='str'),
+        client_cert = dict(required=False, default=os.environ.get('VAULT_CLIENT_CERT', ''), type='str'),
+        client_key = dict(required=False, default=os.environ.get('VAULT_CLIENT_KEY', ''), type='str'),
         verify = dict(required=False, default=(not os.environ.get('VAULT_SKIP_VERIFY', '')), type='bool'),
         authtype = dict(required=False, default='token', type='str'),
         token = dict(required=False, default=hashivault_default_token(), type='str', no_log=True),
@@ -24,15 +28,28 @@ def hashivault_init(argument_spec):
 
 def hashivault_client(params):
     url = params.get('url')
-    verify = params.get('verify')
-    client = hvac.Client(url=url, verify=verify)
+    ca_cert = params.get('ca_cert')
+    ca_path = params.get('ca_path')
+    client_cert = params.get('client_cert')
+    client_key = params.get('client_key')
+    cert = (client_cert, client_key)
+    check_verify = params.get('verify')
+    if check_verify == '' or check_verify;
+        if ca_cert:
+            verify = ca_cert
+        elif ca_path:
+            verify = ca_path
+        else
+            verify = check_verify
+    else:
+        verify = check_verify
+    client = hvac.Client(url=url, cert=cert, verify=verify)
     return client
 
 
 def hashivault_auth(client, params):
     token = params.get('token')
     authtype = params.get('authtype')
-    token = params.get('token')
     username = params.get('username')
     password = params.get('password')
     if authtype == 'github':

--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -9,10 +9,6 @@ from ansible.module_utils.basic import AnsibleModule
 def hashivault_argspec():
     argument_spec = dict(
         url = dict(required=False, default=os.environ.get('VAULT_ADDR', ''), type='str'),
-        ca_cert = dict(required=False, default=os.environ.get('VAULT_CACERT', ''), type='str'),
-        ca_path = dict(required=False, default=os.environ.get('VAULT_CAPATH', ''), type='str'),
-        client_cert = dict(required=False, default=os.environ.get('VAULT_CLIENT_CERT', ''), type='str'),
-        client_key = dict(required=False, default=os.environ.get('VAULT_CLIENT_KEY', ''), type='str'),
         verify = dict(required=False, default=(not os.environ.get('VAULT_SKIP_VERIFY', '')), type='bool'),
         authtype = dict(required=False, default='token', type='str'),
         token = dict(required=False, default=hashivault_default_token(), type='str', no_log=True),
@@ -28,28 +24,15 @@ def hashivault_init(argument_spec):
 
 def hashivault_client(params):
     url = params.get('url')
-    ca_cert = params.get('ca_cert')
-    ca_path = params.get('ca_path')
-    client_cert = params.get('client_cert')
-    client_key = params.get('client_key')
-    cert = (client_cert, client_key)
-    check_verify = params.get('verify')
-    if check_verify == '' or check_verify;
-        if ca_cert:
-            verify = ca_cert
-        elif ca_path:
-            verify = ca_path
-        else
-            verify = check_verify
-    else:
-        verify = check_verify
-    client = hvac.Client(url=url, cert=cert, verify=verify)
+    verify = params.get('verify')
+    client = hvac.Client(url=url, verify=verify)
     return client
 
 
 def hashivault_auth(client, params):
     token = params.get('token')
     authtype = params.get('authtype')
+    token = params.get('token')
     username = params.get('username')
     password = params.get('password')
     if authtype == 'github':

--- a/ansible/modules/hashivault/hashivault_audit_enable.py
+++ b/ansible/modules/hashivault/hashivault_audit_enable.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_audit_list.py
+++ b/ansible/modules/hashivault/hashivault_audit_list.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_auth_enable.py
+++ b/ansible/modules/hashivault/hashivault_auth_enable.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_auth_list.py
+++ b/ansible/modules/hashivault/hashivault_auth_list.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_delete.py
+++ b/ansible/modules/hashivault/hashivault_delete.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_init.py
+++ b/ansible/modules/hashivault/hashivault_init.py
@@ -11,25 +11,9 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
+            - verify TLS certificate
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_init.py
+++ b/ansible/modules/hashivault/hashivault_init.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -14,9 +14,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_policy_delete.py
+++ b/ansible/modules/hashivault/hashivault_policy_delete.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_policy_get.py
+++ b/ansible/modules/hashivault/hashivault_policy_get.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_policy_list.py
+++ b/ansible/modules/hashivault/hashivault_policy_list.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_policy_set.py
+++ b/ansible/modules/hashivault/hashivault_policy_set.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_rekey.py
+++ b/ansible/modules/hashivault/hashivault_rekey.py
@@ -12,9 +12,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_rekey_cancel.py
+++ b/ansible/modules/hashivault/hashivault_rekey_cancel.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_rekey_init.py
+++ b/ansible/modules/hashivault/hashivault_rekey_init.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_rekey_status.py
+++ b/ansible/modules/hashivault/hashivault_rekey_status.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_seal.py
+++ b/ansible/modules/hashivault/hashivault_seal.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_secret_disable.py
+++ b/ansible/modules/hashivault/hashivault_secret_disable.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_secret_enable.py
+++ b/ansible/modules/hashivault/hashivault_secret_enable.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_secret_list.py
+++ b/ansible/modules/hashivault/hashivault_secret_list.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_status.py
+++ b/ansible/modules/hashivault/hashivault_status.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_token_create.py
+++ b/ansible/modules/hashivault/hashivault_token_create.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_token_lookup.py
+++ b/ansible/modules/hashivault/hashivault_token_lookup.py
@@ -12,9 +12,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_unseal.py
+++ b/ansible/modules/hashivault/hashivault_unseal.py
@@ -11,25 +11,9 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
+            - verify TLS certificate
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_unseal.py
+++ b/ansible/modules/hashivault/hashivault_unseal.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_userpass_create.py
+++ b/ansible/modules/hashivault/hashivault_userpass_create.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_userpass_delete.py
+++ b/ansible/modules/hashivault/hashivault_userpass_delete.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -11,9 +11,25 @@ options:
         description:
             - url for vault
         default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
     verify:
         description:
-            - verify TLS certificate
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
         default: to environment variable VAULT_SKIP_VERIFY
     authtype:
         description:


### PR DESCRIPTION
Adds support for using strong, (potentially) mutually-authenticated
TLS connections to Hashicorp Vault API.

Adds parameters to allow user to specify paths for client cert and
client key in order to support TLS mutual authentication with Vault
HTTP API, where the hvac client includes Python 'requests' and passes
the client cert and client key as a tuple argument to the 'cert' param
supplied to a requests.Session object. Depending on what params/values
are supplied by user, the value for 'verify' (as passed to the
requests.Session object) will be either True, False, or (preferrably)
the path to a CA cert or directory of CA certs to use for TLS auth
validation.

Updates argument_spec with new params for TLS client authentication :

-  ca_cert
-  ca_path
-  client_cert
-  client_key

Updates documentation with info about ^^new params^^ and their defaults.