### PR TITLE
Add mount tune module

### DIFF
--- a/ansible/modules/hashivault/hashivault_mount_tune.py
+++ b/ansible/modules/hashivault/hashivault_mount_tune.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+DOCUMENTATION = '''
+---
+module: hashivault_auth_enable
+version_added: "3.5.2"
+short_description: Hashicorp Vault auth enable module
+description:
+    - Module to enable authentication backends in Hashicorp Vault.
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+    password:
+        description:
+            - password to login to vault.
+    name:
+        description:
+            - name of authenticator
+    description:
+        description:
+            - description of authenticator
+    mount_point
+        description:
+            - location where this auth backend will be mounted 
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_auth_enable:
+        name: "userpass"
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['mount_point'] = dict(required=True, type='str')
+    argspec['default_lease_ttl'] = dict(required=False, type='int', default=None)
+    argspec['max_lease_ttl'] = dict(required=False, type='int', default=None)
+    module = hashivault_init(argspec)
+    result = hashivault_mount_tune(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.hashivault import *
+
+@hashiwrapper
+def hashivault_mount_tune(module):
+    client = hashivault_auth_client(module.params)
+    mount_point = module.params.get('mount_point')
+    default_lease_ttl = module.params.get('default_lease_ttl')
+    max_lease_ttl = module.params.get('max_lease_ttl')
+
+    changed = False
+    current_tuning = client.get_secret_backend_tuning(None, mount_point=mount_point)
+    current_default_lease_ttl = current_tuning.get('default_lease_ttl')
+    current_max_lease_ttl = current_tuning.get('max_lease_ttl')
+
+    if (current_default_lease_ttl != default_lease_ttl) or (current_max_lease_ttl != max_lease_ttl):
+        changed = True
+
+    if not module.check_mode:
+        client.tune_secret_backend(None, mount_point=mount_point, default_lease_ttl=default_lease_ttl, max_lease_ttl=max_lease_ttl)
+
+    return {'changed': changed}
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_mount_tune.py
+++ b/ansible/modules/hashivault/hashivault_mount_tune.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 DOCUMENTATION = '''
 ---
-module: hashivault_auth_enable
+module: hashivault_mount_tune
 version_added: "3.5.2"
-short_description: Hashicorp Vault auth enable module
+short_description: Hashicorp Vault tune backend
 description:
-    - Module to enable authentication backends in Hashicorp Vault.
+    - Module to enable tuning of backends in HashiCorp Vault.
 options:
     url:
         description:
@@ -45,15 +45,15 @@ options:
     password:
         description:
             - password to login to vault.
-    name:
-        description:
-            - name of authenticator
-    description:
-        description:
-            - description of authenticator
     mount_point
         description:
-            - location where this auth backend will be mounted 
+            - location where this auth backend will be mounted
+    default_lease_ttl:
+        description:
+            - Configures the default lease duration for tokens and secrets. This is an integer value in seconds.
+    max_lease_ttl:
+        description:
+            - Configures the maximum lease duration for tokens and secrets. This is an integer value in seconds.
 '''
 EXAMPLES = '''
 ---

--- a/functional/test_secret.yml
+++ b/functional/test_secret.yml
@@ -91,6 +91,24 @@
     - assert: { that: "{{vault_read.changed}} == False" }
     - assert: { that: "'{{vault_read.msg}}' == 'Secret ephemeral/name is not in vault'" }
 
+    - name: Tune ephermal secret store
+      hashivault_mount_tune:
+        mount_point: ephemeral
+        default_lease_ttl: 3600
+        max_lease_ttl: 8600
+      register: vault_tune
+    - assert: { that: "{{ vault_tune.changed }} == True" }
+    - assert: { that: "{{ vault_tune.rc }} == 0" }
+
+    - name: Idempotent tuning ephermal secret store
+      hashivault_mount_tune:
+        mount_point: ephemeral
+        default_lease_ttl: 3600
+        max_lease_ttl: 8600
+      register: vault_tune
+    - assert: { that: "{{ vault_tune.changed }} == False" }
+    - assert: { that: "{{ vault_tune.rc }} == 0" }
+
     - name: Disable ephermeral secret store
       hashivault_secret_disable:
         name: "ephemeral"


### PR DESCRIPTION
Adds the ability to tune a mount using the module. This introduces a dependency on hvac 0.3.0, but this is not versioned in setup.py so a new install would pull latest.