### PR TITLE
Changed flag support for hashivault_write

### DIFF
--- a/functional/test_secret.yml
+++ b/functional/test_secret.yml
@@ -35,7 +35,52 @@
       hashivault_write:
         secret: 'name'
         data:
+            value: 'old_secret_stuff'
+      register: 'vault_write'
+    - assert:
+        that:
+          - "{{vault_write.changed}} == True"
+          - "'{{vault_write.msg}}' == 'Secret secret/name written'"
+
+    - name: Overwrite a value to the secret store
+      hashivault_write:
+        secret: 'name'
+        data:
             value: 'secret_stuff'
+      register: 'vault_write'
+    - assert:
+        that:
+          - "{{vault_write.changed}} == True"
+          - "'{{vault_write.msg}}' == 'Secret secret/name written'"
+
+    - name: Overwrite an already present value to the secret store
+      hashivault_write:
+        secret: 'name'
+        data:
+            value: 'secret_stuff'
+      register: 'vault_write'
+    - assert: { that: "{{vault_write.changed}} == False" }
+
+    - name: Update a value to the secret store
+      hashivault_write:
+        secret: 'name'
+        update: True
+        data:
+            other_value: 'other_secret_stuff'
+      register: 'vault_write'
+    - assert:
+        that:
+          - "{{vault_write.changed}} == True"
+          - "'{{vault_write.msg}}' == 'Secret secret/name written'"
+
+    - name: Update an already value to the secret store
+      hashivault_write:
+        secret: 'name'
+        update: True
+        data:
+            other_value: 'other_secret_stuff'
+      register: 'vault_write'
+    - assert: { that: "{{vault_write.changed}} == False" }
 
     - name: Read the secret value
       hashivault_read:


### PR DESCRIPTION
#### `changed` flag support for the `hashivault_write` task

I'd like to be able to track what was already inside vault before the launch of my playbooks...
I also refactored the method a bit.

HTH