### PR TITLE
hashivault_policy_get fail on None return

### DIFF
--- a/ansible/modules/hashivault/hashivault_policy_get.py
+++ b/ansible/modules/hashivault/hashivault_policy_get.py
@@ -79,9 +79,17 @@ from ansible.module_utils.hashivault import *
 
 @hashiwrapper
 def hashivault_policy_get(params):
+    result = { "changed": False, "rc" : 0}
     name = params.get('name')
     client = hashivault_auth_client(params)
-    return {'rules': client.get_policy(name)}
+    policy = client.get_policy(name)
+    if policy is None:
+      result['rc'] = 1
+      result['failed'] = True
+      result['msg'] = "Policy \"%s\" does not exist." % (name)
+      return result
+    else:
+      return {'rules': policy}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Right now hashivault_policy_get will return with a positive return code even on a non-existent policy.  Changed the return code to fail on a non-existent policy.