### PR TITLE
Adding TLS auth option

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -65,6 +65,8 @@ def hashivault_auth(client, params):
         client.auth_ldap(username, password)
     elif authtype == 'approle':
         client = AppRoleClient(client,role_id,secret_id)
+    elif authtype == 'tls':
+        client.auth_tls()
     else:
         client.token = token
     return client


### PR DESCRIPTION
Hi,

I've noticed that despite having the option to provide client certs the option to do TLS auth is not available. This PR solves this by adding a new option called `tls` and using the underlying `auth_tls()` method.