### PR TITLE
Strip Vault token read from file

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -97,7 +97,7 @@ def hashivault_default_token():
     token_file = os.path.expanduser('~/.vault-token')
     if os.path.exists(token_file):
         with open(token_file, 'r') as f:
-            return f.read()
+            return f.read().strip()
     return ''
 
 


### PR DESCRIPTION
Avoid `Invalid header value` error when `~/.vault-token` has empty line following the token, e.g. when periodic token is written to file manually using `nano` for some service user.