### PR TITLE
Fix missing cert info for lookups.

### DIFF
--- a/ansible/plugins/lookup/hashivault.py
+++ b/ansible/plugins/lookup/hashivault.py
@@ -48,6 +48,10 @@ class LookupModule(LookupBase):
         }
         authtype = os.getenv('VAULT_AUTHTYPE', 'token')
         params['authtype'] = authtype
+        params['ca_cert'] = os.getenv('VAULT_CACERT')
+        params['ca_path'] = os.getenv('VAULT_CAPATH')
+        params['client_cert'] = os.getenv('VAULT_CLIENT_CERT')
+        params['client_key'] = os.getenv('VAULT_CLIENT_KEY')
         if authtype == 'approle':
             params['role_id'] = os.getenv('VAULT_ROLE_ID')
             params['secret_id'] = os.getenv('VAULT_SECRET_ID')


### PR DESCRIPTION
I'm only using this module for lookups in group_vars. But in my scenario, none of the certificate information was actually being collected before the module would initialize a vault client and attempt to connect to the vault server. This PR only adds lookups for cert environment variables.