### PR TITLE
Tweak Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,7 @@ The following variables need to be exported to the environment where you run ans
 in order to authenticate to your HashiCorp Vault instance:
 
   * `VAULT_ADDR`: url for vault
-  * `VAULT_SKIP_VERIFY=true`: if set, do not verify presented TLS certificate before communicating with Vault server.
-  Setting this variable is not recommended except during testing
+  * `VAULT_SKIP_VERIFY=true`: if set, do not verify presented TLS certificate before communicating with Vault server. Setting this variable is not recommended except during testing
   * `VAULT_AUTHTYPE`: authentication type to use: `token`, `userpass`, `github`, `ldap`, `approle`
   * `VAULT_TOKEN`: token for vault
   * `VAULT_ROLE_ID`: (required by `approle`)


### PR DESCRIPTION
RST format wasn't making it clear which environment variables were being read. This tiny tweak fixes that, so on Github it will be formatted correctly.