### PR TITLE
Fix auth_methods for LDAP and GitHub

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -76,11 +76,11 @@ def hashivault_auth(client, params):
     role_id = params.get('role_id')
 
     if authtype == 'github':
-        client.auth_methods.Github.login(token)
+        client.auth.github.login(token)
     elif authtype == 'userpass':
         client.auth_userpass(username, password)
     elif authtype == 'ldap':
-        client.auth_methods.Ldap.login(username, password)
+        client.auth.ldap.login(username, password)
     elif authtype == 'approle':
         client = AppRoleClient(client,role_id,secret_id)
     elif authtype == 'tls':


### PR DESCRIPTION
This PR fixes the following error:
```
{"changed": false, "failed": true, "item": "foo", "msg": "Exception: 'Client' has no attribute 'auth_methods'", "rc": 1}
```

Docs refs:
[LDAP - Authentication / Login](https://github.com/hvac/hvac/blob/develop/docs/usage/auth_methods/ldap.rst#authentication--login)
[GitHub - Authentication / Login](https://github.com/hvac/hvac/blob/develop/docs/usage/auth_methods/github.rst#authentication--login)