### PR TITLE
optionally include namespace as play parameter or environment var

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ in order to authenticate to your HashiCorp Vault instance:
   * `VAULT_CLIENT_CERT`: path to a PEM-encoded client certificate for TLS authentication to the Vault server
   * `VAULT_CACERT`: path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate
   * `VAULT_CAPATH`: path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate
+  * `VAULT_NAMESPACE`: specify the Vault Namespace, if you have one
 
 
 Reading and Writing

--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -19,7 +19,8 @@ def hashivault_argspec():
         username = dict(required=False, default=os.environ.get('VAULT_USER', ''), type='str'),
         password = dict(required=False, default=os.environ.get('VAULT_PASSWORD', ''), type='str', no_log=True),
         role_id = dict(required=False, default=os.environ.get('VAULT_ROLE_ID', ''), type='str', no_log=True),
-        secret_id = dict(required=False, default=os.environ.get('VAULT_SECRET_ID', ''), type='str', no_log=True)
+        secret_id = dict(required=False, default=os.environ.get('VAULT_SECRET_ID', ''), type='str', no_log=True),
+        namespace = dict(required=False, default=os.environ.get('VAULT_NAMESPACE', None), type='str')
     )
     return argument_spec
 
@@ -36,6 +37,7 @@ def hashivault_client(params):
     client_key = params.get('client_key')
     cert = (client_cert, client_key)
     check_verify = params.get('verify')
+    namespace = params.get('namespace', None)
     if check_verify == '' or check_verify:
         if ca_cert:
             verify = ca_cert
@@ -45,7 +47,7 @@ def hashivault_client(params):
             verify = check_verify
     else:
         verify = check_verify
-    client = hvac.Client(url=url, cert=cert, verify=verify)
+    client = hvac.Client(url=url, cert=cert, verify=verify, namespace=namespace)
     return client
 
 


### PR DESCRIPTION
Vault enterprise allows for segmenting youre vault into 'mini-vaults' called Namespaces. this PR allows you allows you to take advantage of HVAC 0.7s ability to inject the namespace as a http header when creating the Client object

you can specify the namespace in 2 ways:
1. as a param in your ansible play
2. as an environment variable VAULT_NAMESPACE

tested execution on vault 1.0:
1. as a param in your ansible play
2. as an environment variable VAULT_NAMESPACE
3. with VAULT_NAMESPACE=""
4. without setting VAULT_NAMESPACE or namespace in play