### PR TITLE
add kv engine v2 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ reads the fie value::
           register: 'vault_status'
         - hashivault_write:
             secret: 'giant'
+            version: 2
             data:
                 foo: '{{foo_value}}'
                 fie: '{{fie_value}}'

--- a/ansible/modules/hashivault/hashivault_delete.py
+++ b/ansible/modules/hashivault/hashivault_delete.py
@@ -63,6 +63,7 @@ EXAMPLES = '''
 def main():
     argspec = hashivault_argspec()
     argspec['secret'] = dict(required=True, type='str')
+    argspec['version'] = dict(required=False, type='int', default=1)
     module = hashivault_init(argspec)
     result = hashivault_delete(module.params)
     if result.get('failed'):
@@ -78,9 +79,13 @@ from ansible.module_utils.hashivault import *
 def hashivault_delete(params):
     result = { "changed": False, "rc" : 0}
     client = hashivault_auth_client(params)
+    version = params.get('version')
     secret = params.get('secret')
     if secret.startswith('/'):
         secret = secret.lstrip('/')
+
+    if version == 2:
+        secret = (u'secret/data/%s' % secret)
     else:
         secret = (u'secret/%s' % secret)
     with warnings.catch_warnings():

--- a/ansible/modules/hashivault/hashivault_delete.py
+++ b/ansible/modules/hashivault/hashivault_delete.py
@@ -50,6 +50,10 @@ options:
     secret:
         description:
             - secret to delete.
+    version:
+        description:
+            - version of the kv engine (int)
+        default: 1
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -53,7 +53,7 @@ options:
     version:
         description:
             - version of the kv engine (int)
-        default: 2
+        default: 1
     key:
         description:
             - secret key to read.

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -104,7 +104,6 @@ def hashivault_read(params):
         warnings.simplefilter("ignore")
         if secret.startswith('/'):
             secret = secret.lstrip('/')
-            response = client.read(secret)
 
         if version == 2:
             response = client.read(u'secret/data/%s' % secret)
@@ -118,7 +117,10 @@ def hashivault_read(params):
             result['failed'] = True
             result['msg'] = u"Secret %s is not in vault" % secret
             return result
-        data = response['data']
+        if version == 2:
+            data = response['data']['data']
+        else:
+            data = response['data']
     if key and key not in data:
         if default is not None:
             result['value'] = default

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -105,7 +105,8 @@ def hashivault_read(params):
         if secret.startswith('/'):
             secret = secret.lstrip('/')
             response = client.read(secret)
-        elif version == 2:
+
+        if version == 2:
             response = client.read(u'secret/data/%s' % secret)
         else:
             response = client.read(u'secret/%s' % secret)

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -50,6 +50,10 @@ options:
     secret:
         description:
             - secret to read.
+    version:
+        description:
+            - version of the kv engine (int)
+        default: 2
     key:
         description:
             - secret key to read.
@@ -73,6 +77,7 @@ def main():
     argspec = hashivault_argspec()
     argspec['secret'] = dict(required=True, type='str')
     argspec['key'] = dict(required=False, type='str')
+    argspec['version'] = dict(required=False, type='int', default=2)
     argspec['register'] = dict(required=False, type='str')
     argspec['default'] = dict(required=False, default=None, type='str')
     module = hashivault_init(argspec)
@@ -92,6 +97,7 @@ def hashivault_read(params):
     result = { "changed": False, "rc" : 0}
     client = hashivault_auth_client(params)
     secret = params.get('secret')
+    version = params.get('version')
     key = params.get('key')
     default = params.get('default')
     with warnings.catch_warnings():
@@ -99,6 +105,8 @@ def hashivault_read(params):
         if secret.startswith('/'):
             secret = secret.lstrip('/')
             response = client.read(secret)
+        elif version == 2:
+            response = client.read(u'secret/data/%s' % secret)
         else:
             response = client.read(u'secret/%s' % secret)
         if not response:

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -77,7 +77,7 @@ def main():
     argspec = hashivault_argspec()
     argspec['secret'] = dict(required=True, type='str')
     argspec['key'] = dict(required=False, type='str')
-    argspec['version'] = dict(required=False, type='int', default=2)
+    argspec['version'] = dict(required=False, type='int', default=1)
     argspec['register'] = dict(required=False, type='str')
     argspec['default'] = dict(required=False, default=None, type='str')
     module = hashivault_init(argspec)

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -141,13 +141,15 @@ def hashivault_write(module):
 
     if secret.startswith('/'):
         secret = secret.lstrip('/')
+
     # if kv engine is v2
-    elif version == 2:
+    if version == 2:
         secret = ('secret/data/%s' % secret)
         data = dict(data=params.get('data'))
     else:
         secret = ('secret/%s' % secret)
         data = params.get('data')
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         changed = True

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -141,11 +141,13 @@ def hashivault_write(module):
 
     if secret.startswith('/'):
         secret = secret.lstrip('/')
+    # if kv engine is v2
     elif version == 2:
         secret = ('secret/data/%s' % secret)
+        data = dict(data=params.get('data'))
     else:
         secret = ('secret/%s' % secret)
-    data = params.get('data')
+        data = params.get('data')
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         changed = True

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -50,6 +50,10 @@ options:
     secret:
         description:
             - vault secret to write.
+    version:
+        description:
+            - version of the kv engine (int)
+        default: 2
     data:
         description:
             - Keys and values to write.
@@ -64,6 +68,7 @@ EXAMPLES = '''
   tasks:
     - hashivault_write:
         secret: giant
+        version: 1
         data:
             foo: foe
             fie: fum

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -53,7 +53,7 @@ options:
     version:
         description:
             - version of the kv engine (int)
-        default: 2
+        default: 1
     data:
         description:
             - Keys and values to write.

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -73,6 +73,7 @@ EXAMPLES = '''
 def main():
     argspec = hashivault_argspec()
     argspec['secret'] = dict(required=True, type='str')
+    argspec['version'] = dict(required=False, type='int', default=2)
     argspec['update'] = dict(required=False, default=False, type='bool')
     argspec['data'] = dict(required=False, default={}, type='dict')
     module = hashivault_init(argspec, supports_check_mode=True)
@@ -130,10 +131,13 @@ def hashivault_write(module):
     params = module.params
     client = hashivault_auth_client(params)
     secret = params.get('secret')
+    version = params.get('version')
     returned_data = None
 
     if secret.startswith('/'):
         secret = secret.lstrip('/')
+    elif version == 2:
+        secret = ('secret/data/%s' % secret)
     else:
         secret = ('secret/%s' % secret)
     data = params.get('data')

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -78,7 +78,7 @@ EXAMPLES = '''
 def main():
     argspec = hashivault_argspec()
     argspec['secret'] = dict(required=True, type='str')
-    argspec['version'] = dict(required=False, type='int', default=2)
+    argspec['version'] = dict(required=False, type='int', default=1)
     argspec['update'] = dict(required=False, default=False, type='bool')
     argspec['data'] = dict(required=False, default={}, type='dict')
     module = hashivault_init(argspec, supports_check_mode=True)

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -21,7 +21,7 @@ ansible-playbook -v test_secret_list.yml
 ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml
-ansible-playbook -vvv test_ephemeral.yml
+ansible-playbook -v test_ephemeral.yml
 ansible-playbook -v test_tokens.yml
 ansible-playbook -v test_audit.yml
 ansible-playbook -v test_read_write_file.yml

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -22,6 +22,7 @@ ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml
 ansible-playbook -v test_ephemeral.yml
+ansible-playbook -v test_secret_v2.yml
 ansible-playbook -v test_tokens.yml
 ansible-playbook -v test_audit.yml
 ansible-playbook -v test_read_write_file.yml

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -21,7 +21,7 @@ ansible-playbook -v test_secret_list.yml
 ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml
-ansible-playbook -v test_ephemeral.yml
+ansible-playbook -vvv test_ephemeral.yml
 ansible-playbook -v test_tokens.yml
 ansible-playbook -v test_audit.yml
 ansible-playbook -v test_read_write_file.yml

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -22,7 +22,7 @@ ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml
 ansible-playbook -v test_ephemeral.yml
-ansible-playbook -vvv test_secret_v2.yml
+ansible-playbook -v test_secret_v2.yml
 ansible-playbook -v test_tokens.yml
 ansible-playbook -v test_audit.yml
 ansible-playbook -v test_read_write_file.yml

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -22,7 +22,7 @@ ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml
 ansible-playbook -v test_ephemeral.yml
-ansible-playbook -v test_secret_v2.yml
+ansible-playbook -vvv test_secret_v2.yml
 ansible-playbook -v test_tokens.yml
 ansible-playbook -v test_audit.yml
 ansible-playbook -v test_read_write_file.yml

--- a/functional/test_ephemeral.yml
+++ b/functional/test_ephemeral.yml
@@ -45,7 +45,7 @@
       register: 'vault_secret_eph_delete'
     - assert: { that: "{{vault_secret_eph_delete.changed}} == True" }
     - assert: { that: "{{vault_secret_eph_delete.rc}} == 0" }
-    - assert: { that: "'{{vault_secret_eph_delete.msg}}' == 'Secret ephemeral/name deleted'" }
+    - assert: { that: "'{{vault_secret_eph_delete.msg}}' == 'Secret secret/ephemeral/name deleted'" }
 
     - name: Make sure ephemeral value is gone
       hashivault_read:

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -12,7 +12,7 @@
         name: "kv2"
         backend: "kv"
         options:
-          version: "2"
+          version: 2
       register: 'vault_secret_enable'
     - assert: { that: "{{vault_secret_enable.changed}} == True" }
     - assert: { that: "{{vault_secret_enable.rc}} == 0" }
@@ -22,7 +22,7 @@
         name: "kv2"
         backend: "kv"
         options:
-          version: "2"
+          version: 2
       register: 'vault_secret_enable_twice'
     - assert: { that: "{{vault_secret_enable_twice.changed}} == False" }
     - assert: { that: "{{vault_secret_enable_twice.rc}} == 0" }
@@ -30,7 +30,7 @@
     - name: Write a value to the kv2 store
       hashivault_write:
         secret: '/kv2/name'
-        version: "2"
+        version: 2
         data:
             value: 'kv2_stuff'
 
@@ -38,7 +38,7 @@
       hashivault_read:
         secret: '/kv2/name'
         key: 'value'
-        version: "2"
+        version: 2
       register: 'vault_read'
     - assert: { that: "'{{vault_read.value}}' == 'kv2_stuff'" }
 
@@ -49,7 +49,7 @@
     - name: Delete kv2 secret
       hashivault_delete:
         secret: '/kv2/name'
-        version: "2"
+        version: 2
       register: 'vault_secret_eph_delete'
     - assert: { that: "{{vault_secret_eph_delete.changed}} == True" }
     - assert: { that: "{{vault_secret_eph_delete.rc}} == 0" }
@@ -58,7 +58,7 @@
     - name: Make sure kv2 value is gone
       hashivault_read:
         secret: '/kv2/name'
-        version: "2"
+        version: 2
       register: 'vault_read'
       failed_when: False
     - assert: { that: "{{vault_read.changed}} == False" }

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -29,6 +29,7 @@
     - name: Write a value to the kv2 store
       hashivault_write:
         secret: '/kv2/name'
+        version: "2"
         data:
             value: 'kv2_stuff'
 
@@ -36,16 +37,18 @@
       hashivault_read:
         secret: '/kv2/name'
         key: 'value'
+        version: "2"
       register: 'vault_read'
     - assert: { that: "'{{vault_read.value}}' == 'kv2_stuff'" }
 
-    - set_fact:
-        looky_kv2: "{{lookup('hashivault', '/kv2/name', 'value')}}"
-    - assert: { that: "'{{looky_kv2}}' == 'kv2_stuff'" }
+    # - set_fact:
+    #     looky_kv2: "{{lookup('hashivault', '/kv2/name', 'value')}}"
+    # - assert: { that: "'{{looky_kv2}}' == 'kv2_stuff'" }
 
     - name: Delete kv2 secret
       hashivault_delete:
         secret: '/kv2/name'
+        version: "2"
       register: 'vault_secret_eph_delete'
     - assert: { that: "{{vault_secret_eph_delete.changed}} == True" }
     - assert: { that: "{{vault_secret_eph_delete.rc}} == 0" }
@@ -54,6 +57,7 @@
     - name: Make sure kv2 value is gone
       hashivault_read:
         secret: '/kv2/name'
+        version: "2"
       register: 'vault_read'
       failed_when: False
     - assert: { that: "{{vault_read.changed}} == False" }
@@ -80,6 +84,7 @@
     - name: Disable kv2 secret store
       hashivault_secret_disable:
         name: "kv2"
+        version: "2"
       register: 'vault_secret_disable'
     - assert: { that: "{{vault_secret_enable.changed}} == True" }
     - assert: { that: "{{vault_secret_enable.rc}} == 0" }

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -53,7 +53,7 @@
       register: 'vault_secret_eph_delete'
     - assert: { that: "{{vault_secret_eph_delete.changed}} == True" }
     - assert: { that: "{{vault_secret_eph_delete.rc}} == 0" }
-    - assert: { that: "'{{vault_secret_eph_delete.msg}}' == 'Secret secret/kv2/name deleted'" }
+    - assert: { that: "'{{vault_secret_eph_delete.msg}}' == 'Secret secret/data/kv2/name deleted'" }
 
     - name: Make sure kv2 value is gone
       hashivault_read:

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -9,7 +9,6 @@
     - name: Enable kv2 secret store
       hashivault_secret_enable:
         name: "kv2"
-        backend: "generic"
         options:
           version: "2"
       register: 'vault_secret_enable'
@@ -19,7 +18,6 @@
     - name: Enable same secret store again and check it doesn't fail
       hashivault_secret_enable:
         name: "kv2"
-        backend: "generic"
         options:
           version: "2"
       register: 'vault_secret_enable_twice'

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -1,0 +1,85 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Make sure kv2 secret store is disabled
+      hashivault_secret_disable:
+        name: "kv2"
+      failed_when: False
+    - name: Enable kv2 secret store
+      hashivault_secret_enable:
+        name: "kv2"
+        backend: "generic"
+        options:
+          version: "2"
+      register: 'vault_secret_enable'
+    - assert: { that: "{{vault_secret_enable.changed}} == True" }
+    - assert: { that: "{{vault_secret_enable.rc}} == 0" }
+
+    - name: Enable same secret store again and check it doesn't fail
+      hashivault_secret_enable:
+        name: "kv2"
+        backend: "generic"
+        options:
+          version: "2"
+      register: 'vault_secret_enable_twice'
+    - assert: { that: "{{vault_secret_enable_twice.changed}} == False" }
+    - assert: { that: "{{vault_secret_enable_twice.rc}} == 0" }
+
+    - name: Write a value to the kv2 store
+      hashivault_write:
+        secret: '/kv2/name'
+        data:
+            value: 'kv2_stuff'
+
+    - name: Read the kv2 value
+      hashivault_read:
+        secret: '/kv2/name'
+        key: 'value'
+      register: 'vault_read'
+    - assert: { that: "'{{vault_read.value}}' == 'kv2_stuff'" }
+
+    - set_fact:
+        looky_kv2: "{{lookup('hashivault', '/kv2/name', 'value')}}"
+    - assert: { that: "'{{looky_kv2}}' == 'kv2_stuff'" }
+
+    - name: Delete kv2 secret
+      hashivault_delete:
+        secret: '/kv2/name'
+      register: 'vault_secret_eph_delete'
+    - assert: { that: "{{vault_secret_eph_delete.changed}} == True" }
+    - assert: { that: "{{vault_secret_eph_delete.rc}} == 0" }
+    - assert: { that: "'{{vault_secret_eph_delete.msg}}' == 'Secret secret/kv2/name deleted'" }
+
+    - name: Make sure kv2 value is gone
+      hashivault_read:
+        secret: '/kv2/name'
+      register: 'vault_read'
+      failed_when: False
+    - assert: { that: "{{vault_read.changed}} == False" }
+    - assert: { that: "'{{vault_read.msg}}' == 'Secret kv2/name is not in vault'" }
+
+    - name: Tune kv2 secret store
+      hashivault_mount_tune:
+        mount_point: kv2
+        default_lease_ttl: 3600
+        max_lease_ttl: 8600
+      register: vault_tune
+    - assert: { that: "{{ vault_tune.changed }} == True" }
+    - assert: { that: "{{ vault_tune.rc }} == 0" }
+
+    - name: Idempotent tuning kv2 secret store
+      hashivault_mount_tune:
+        mount_point: kv2
+        default_lease_ttl: 3600
+        max_lease_ttl: 8600
+      register: vault_tune
+    - assert: { that: "{{ vault_tune.changed }} == False" }
+    - assert: { that: "{{ vault_tune.rc }} == 0" }
+
+    - name: Disable kv2 secret store
+      hashivault_secret_disable:
+        name: "kv2"
+      register: 'vault_secret_disable'
+    - assert: { that: "{{vault_secret_enable.changed}} == True" }
+    - assert: { that: "{{vault_secret_enable.rc}} == 0" }

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -30,7 +30,7 @@
     - name: Write a value to the kv2 store
       hashivault_write:
         secret: '/kv2/name'
-
+        version: "2"
         data:
             value: 'kv2_stuff'
 

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -9,6 +9,7 @@
     - name: Enable kv2 secret store
       hashivault_secret_enable:
         name: "kv2"
+        backend: "kv"
         options:
           version: "2"
       register: 'vault_secret_enable'
@@ -18,6 +19,7 @@
     - name: Enable same secret store again and check it doesn't fail
       hashivault_secret_enable:
         name: "kv2"
+        backend: "kv"
         options:
           version: "2"
       register: 'vault_secret_enable_twice'
@@ -27,7 +29,7 @@
     - name: Write a value to the kv2 store
       hashivault_write:
         secret: '/kv2/name'
-        version: "2"
+
         data:
             value: 'kv2_stuff'
 

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -5,7 +5,6 @@
     - name: Make sure kv2 secret store is disabled
       hashivault_secret_disable:
         name: "kv2"
-        backend: "kv"
       failed_when: False
     - name: Enable kv2 secret store
       hashivault_secret_enable:
@@ -85,7 +84,6 @@
     - name: Disable kv2 secret store
       hashivault_secret_disable:
         name: "kv2"
-        backend: "kv"
       register: 'vault_secret_disable'
     - assert: { that: "{{vault_secret_enable.changed}} == True" }
     - assert: { that: "{{vault_secret_enable.rc}} == 0" }

--- a/functional/test_secret_v2.yml
+++ b/functional/test_secret_v2.yml
@@ -5,6 +5,7 @@
     - name: Make sure kv2 secret store is disabled
       hashivault_secret_disable:
         name: "kv2"
+        backend: "kv"
       failed_when: False
     - name: Enable kv2 secret store
       hashivault_secret_enable:
@@ -84,7 +85,7 @@
     - name: Disable kv2 secret store
       hashivault_secret_disable:
         name: "kv2"
-        version: "2"
+        backend: "kv"
       register: 'vault_secret_disable'
     - assert: { that: "{{vault_secret_enable.changed}} == True" }
     - assert: { that: "{{vault_secret_enable.rc}} == 0" }


### PR DESCRIPTION
fix for: https://github.com/TerryHowe/ansible-modules-hashivault/issues/68

add a new parameter option: `version` that takes an integer. default `1`. include tests for CI to create kv2 engine and perform write, read, delete, then disable engine

example play
```
    - name: terry howe vault write with kv2
      hashivault_write:
        url: vault.example.com
        verify: false
        token: <redacted>
        secret: test2
        data:
            password: mypass
        version: 2
        namespace: my/teamnamespace/kv2
```