### PR TITLE
Add pipeline job to build Ansible webdocs and publish to Github pages…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,49 @@
-sudo: required
+stages: 
+  - test
+
 language: python
-python:
-  - "2.7"
-  - "3.6"
-services:
-  - docker
-before_install:
-  - docker pull vault:latest
-  - docker ps -a
-install: pip install tox-travis
-script: tox
+
+jobs:
+  include:
+    - stage: test
+      name: "Tests"
+      sudo: required
+      python:
+        - "2.7"
+        - "3.6"
+      services:
+        - docker
+      before_install:
+        - docker pull vault:latest
+        - docker ps -a
+      install: pip install tox-travis
+      script: tox
+
+    - stage: test
+      name: "Generating docs"
+      python: "3.6"
+      deploy:
+        local-dir: ansible-repo/ansible/docs/docsite/_build/html
+        provider: pages
+        skip-cleanup: true
+        github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+        keep-history: true
+        on: 
+          tags: true
+      env: 
+        - PLUGINS=''
+      install: 
+        - mkdir ansible-repo && cd ansible-repo
+        - git clone https://github.com/ansible/ansible.git && cd ansible &&  git checkout v2.7.6 && cd ..
+        - pip install sphinx sphinx_rtd_theme
+        - pip install -r ansible/requirements.txt
+        - rm -rf ansible/lib/ansible/modules/ && mkdir -p ansible/lib/ansible/modules/hashivault
+        - cp -r ../ansible/modules/hashivault/hashivault*.py ansible/lib/ansible/modules/hashivault/
+        - ls ansible/lib/ansible/modules/hashivault
+        - cd ansible/docs/docsite/ 
+      script: 
+      - export MODULES=$(ls -m --hide='_*' ../../lib/ansible/modules/hashivault/ | tr -d '[:space:]'  | sed 's/.py//g')
+      - make webdocs .
+      - touch _build/html/.nojekyll
+      on:
+        tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-stages: 
+stages:
   - test
 
 language: python
@@ -6,10 +6,21 @@ language: python
 jobs:
   include:
     - stage: test
-      name: "Tests"
+      name: "Tests Python 2.7"
       sudo: required
       python:
         - "2.7"
+      services:
+        - docker
+      before_install:
+        - docker pull vault:latest
+        - docker ps -a
+      install: pip install tox-travis
+      script: tox
+    - stage: test
+      name: "Tests Python 3.6"
+      sudo: required
+      python:
         - "3.6"
       services:
         - docker
@@ -18,7 +29,6 @@ jobs:
         - docker ps -a
       install: pip install tox-travis
       script: tox
-
     - stage: test
       name: "Generating docs"
       python: "3.6"
@@ -28,11 +38,11 @@ jobs:
         skip-cleanup: true
         github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
         keep-history: true
-        on: 
+        on:
           tags: true
-      env: 
+      env:
         - PLUGINS=''
-      install: 
+      install:
         - mkdir ansible-repo && cd ansible-repo
         - git clone https://github.com/ansible/ansible.git && cd ansible &&  git checkout v2.7.6 && cd ..
         - pip install sphinx sphinx_rtd_theme
@@ -40,8 +50,8 @@ jobs:
         - rm -rf ansible/lib/ansible/modules/ && mkdir -p ansible/lib/ansible/modules/hashivault
         - cp -r ../ansible/modules/hashivault/hashivault*.py ansible/lib/ansible/modules/hashivault/
         - ls ansible/lib/ansible/modules/hashivault
-        - cd ansible/docs/docsite/ 
-      script: 
+        - cd ansible/docs/docsite/
+      script:
       - export MODULES=$(ls -m --hide='_*' ../../lib/ansible/modules/hashivault/ | tr -d '[:space:]'  | sed 's/.py//g')
       - make webdocs .
       - touch _build/html/.nojekyll

--- a/ansible/modules/hashivault/hashivault_auth_enable.py
+++ b/ansible/modules/hashivault/hashivault_auth_enable.py
@@ -53,7 +53,7 @@ options:
     description:
         description:
             - description of authenticator
-    mount_point
+    mount_point:
         description:
             - location where this auth backend will be mounted 
 '''

--- a/ansible/modules/hashivault/hashivault_mount_tune.py
+++ b/ansible/modules/hashivault/hashivault_mount_tune.py
@@ -47,7 +47,7 @@ options:
         description:
             - password to login to vault.
         default: to environment variable VAULT_PASSWORD
-    mount_point
+    mount_point:
         description:
             - location where this auth backend will be mounted
     default_lease_ttl:


### PR DESCRIPTION
…, Fix YAML issues

Steps to get this working:

In Travis: set the environment variable $GITHUB_TOKEN with a token created on Github
> Setting the GitHub token #
You’ll need to generate a personal access token with the public_repo or repo scope (repo is required for private repositories). Since the token should be private, you’ll want to pass it to Travis securely in your repository settings or via encrypted variables in .travis.yml.

On Github enable Github pages by creating the gh-pages branch

An example of what the resulting documentation is, can be found at https://samycoenen.github.io/ansible-modules-hashivault/modules/list_of_hashivault_modules.html .