### PR TITLE
Fix approle auth for hvac kv2 engine

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -217,9 +217,9 @@ class AppRoleClient(object):
         """
         client = object.__getattribute__(self,'client')
         attr = client.__getattribute__(name)
-        if (callable(attr)):
-            role_id = object.__getattribute__(self,'role_id')
-            secret_id = object.__getattribute__(self,'secret_id')
-            resp = client.auth_approle(role_id,secret_id)
-            client.token = str(resp['auth']['client_token'])
+
+        role_id = object.__getattribute__(self,'role_id')
+        secret_id = object.__getattribute__(self,'secret_id')
+        resp = client.auth_approle(role_id,secret_id)
+        client.token = str(resp['auth']['client_token'])
         return attr


### PR DESCRIPTION
fixes #118 

I think that it is safe to remove the `callable(attr)` conditional - nearly every reference to client in the modules is for the purpose of a making an authenticated call to the API that requires a token.

I'd also be open to implementing more logic around this, since this is really just a quick fix.