### PR TITLE
Add the support for the http method and return json in case of GET method

### DIFF
--- a/ansible/modules/hashivault/hashivault_cluster_status.py
+++ b/ansible/modules/hashivault/hashivault_cluster_status.py
@@ -56,9 +56,13 @@ options:
             - password to login to vault.
         default: to environment variable VAULT_PASSWORD
     standby_ok:
-        description: Specifies if being a standby should still return the active status code instead of the standby status code
-            - password to login to vault.
+        description:
+            - Specifies if being a standby should still return the active status code instead of the standby status code
         default: False
+    method:
+      description:
+        - Method to use to get cluster status, supported methods: HEAD (produces: 000 (empty body)) and GET (produces: 000 application/json)
+      default: HEAD
 '''
 EXAMPLES = '''
 ---
@@ -73,6 +77,7 @@ EXAMPLES = '''
 def main():
     argspec = hashivault_argspec()
     argspec['standby_ok'] = dict(required=False, type='bool', default=True)
+    argspec['method'] = dict(required=False, type='string', default="HEAD")
     module = hashivault_init(argspec)
     result = hashivault_cluster_status(module.params)
     if result.get('failed'):
@@ -84,7 +89,7 @@ def main():
 @hashiwrapper
 def hashivault_cluster_status(params):
     client = hashivault_client(params)
-    response = client.sys.read_health_status(standby_ok=params.get("standby_ok"))
+    response = client.sys.read_health_status(standby_ok=params.get("standby_ok"), method=params.get("method"))
     from requests.models import Response
     if isinstance(response, Response):
         try:
@@ -92,7 +97,7 @@ def hashivault_cluster_status(params):
         except Exception:
             status = response.content
     else:
-        status = str(response)
+        status = response
     return {'status': status}
 
 

--- a/ansible/modules/hashivault/hashivault_cluster_status.py
+++ b/ansible/modules/hashivault/hashivault_cluster_status.py
@@ -61,7 +61,7 @@ options:
         default: False
     method:
       description:
-        - Method to use to get cluster status, supported methods: HEAD (produces: 000 (empty body)) and GET (produces: 000 application/json)
+        - Method to use to get cluster status, supported methods are HEAD (produces 000 (empty body)) and GET (produces 000 application/json)
       default: HEAD
 '''
 EXAMPLES = '''
@@ -77,7 +77,7 @@ EXAMPLES = '''
 def main():
     argspec = hashivault_argspec()
     argspec['standby_ok'] = dict(required=False, type='bool', default=True)
-    argspec['method'] = dict(required=False, type='string', default="HEAD")
+    argspec['method'] = dict(required=False, default="HEAD")
     module = hashivault_init(argspec)
     result = hashivault_cluster_status(module.params)
     if result.get('failed'):

--- a/functional/test_status.yml
+++ b/functional/test_status.yml
@@ -29,3 +29,18 @@
       register: 'vault_status'
     - assert: { that: "{{vault_status.changed}} == False" }
     - assert: { that: "{{vault_status.rc}} == 0" }
+
+    - name: Get hashivault_cluster_status
+      hashivault_cluster_status:
+        method: GET
+      register: 'vault_status'
+    - assert: { that: "{{vault_status.changed}} == False" }
+    - assert: { that: "{{vault_status.rc}} == 0" }
+
+    - name: Get hashivault_cluster_status
+      hashivault_cluster_status:
+        standby_ok: false
+        method: GET
+      register: 'vault_status'
+    - assert: { that: "{{vault_status.changed}} == False" }
+    - assert: { that: "{{vault_status.rc}} == 0" }


### PR DESCRIPTION
Forgot to add the support of the method parameter
Also in case of http GET request vault return a json so I think hashivault doesn't have to format to string