### PR TITLE
Add `mount_point` option to the lookup plugin

### DIFF
--- a/ansible/plugins/lookup/hashivault.py
+++ b/ansible/plugins/lookup/hashivault.py
@@ -46,6 +46,7 @@ class LookupModule(LookupBase):
             key = None
         default = kwargs.get('default', None)
         version = kwargs.get('version')
+        mount_point = kwargs.get('mount_point', 'secret')
         params = {
             'url': self._get_url(environments),
             'verify': self._get_verify(environments),
@@ -53,7 +54,7 @@ class LookupModule(LookupBase):
             'key': key,
             'default': default,
             'version': version,
-            'mount_point': 'secret',
+            'mount_point': mount_point,
         }
         authtype = self._get_environment(environments, 'VAULT_AUTHTYPE', 'token')
         params['authtype'] = authtype


### PR DESCRIPTION
The `mount_point` option is recognized by `hashivault_read` module,
which can be used to override default `secret`. This commit gives
similar capability to `hashivault` lookup plugin.