### PR TITLE
fix key/values should be readed in `.data.data` rather than `.data` i…

### DIFF
--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -184,7 +184,7 @@ def hashivault_write(module):
                 return result
             if not read_data:
                 read_data = {}
-            read_data = read_data.get('data', {})
+            read_data = read_data['data']['data']
 
             write_data = dict(read_data)
             write_data.update(data)

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -184,7 +184,10 @@ def hashivault_write(module):
                 return result
             if not read_data:
                 read_data = {}
-            read_data = read_data['data']['data']
+            read_data = read_data.get('data', {})
+            
+            if version == 2:
+                read_data = read_data.get['data']['data']
 
             write_data = dict(read_data)
             write_data.update(data)


### PR DESCRIPTION
…n kv2

when `update:yes` data is not correctly writed due to a wrong reading path. key/values are stored in 

```
{ data:
   { data: 
      - key1: value1
      - ...
   }
}
```
not in 

```
{ data:
   - key1: value1
   - ...
}
```