### PR TITLE
drewmullen/issue-129 - azure secret engine

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -25,9 +25,8 @@ def hashivault_argspec():
     )
     return argument_spec
 
-
-def hashivault_init(argument_spec, supports_check_mode=False):
-    return AnsibleModule(argument_spec=argument_spec, supports_check_mode=supports_check_mode)
+def hashivault_init(argument_spec, supports_check_mode=False, required_if=None, required_together=None, required_one_of=None, mutually_exclusive=None):
+    return AnsibleModule(argument_spec=argument_spec, supports_check_mode=supports_check_mode, required_together=required_together, mutually_exclusive=mutually_exclusive)
 
 
 def get_ec2_iam_role():

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -139,9 +139,9 @@ def hashivault_azure_secret_engine_config(module):
         client_secret = params.get('client_secret')
 
     # check if engine is enabled
-    client.sys.list_auth_methods().keys()
-    if (mount_point + "/") not in client.sys.list_auth_methods().keys():
-         return {'failed': True, 'msg': 'auth backend is not enabled', 'rc': 1}
+    print(client.sys.list_mounted_secrets_engines()['data'].keys())
+    if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
+         return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
     
     # check if current config matches desired config values, if they match, set changed to false to prevent action
     current = client.secrets.azure.read_config()

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -124,6 +124,10 @@ def hashivault_azure_secret_engine_config(module):
     config_file = params.get('config_file')
     mount_point = params.get('mount_point')
 
+    # do not want a trailing slash in mount_point
+    if mount_point[-1]:
+        mount_point = mount_point.strip('/')
+
     # if config_file is set, set sub_id, ten_id, client_id, client_secret from file
     # else set from passed args
     if config_file:

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -139,10 +139,7 @@ def hashivault_azure_secret_engine_config(module):
         client_secret = params.get('client_secret')
 
     # check if engine is enabled
-    if sys.version_info[0] < 3:
-        if (mount_point + "/") not in json.dumps(client.sys.list_mounted_secrets_engines()['data'].keys()):
-            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
-    elif (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
+    if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
         return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
     
     # check if current config matches desired config values, if they match, set changed to false to prevent action

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -3,9 +3,7 @@ from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
 from ansible.module_utils.hashivault import hashiwrapper
-import json
-import sys
-from ast import literal_eval
+import json, sys
 
 ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
 DOCUMENTATION = '''
@@ -151,15 +149,13 @@ def hashivault_azure_secret_engine_config(module):
     current = client.secrets.azure.read_config()
     if sys.version_info[0] < 3:
         changed = False
-        current_dict = literal_eval(json.dumps(current))
-        for k, v in current_dict.items():
-            for k2, v2, in params.items():
-                if k == k2:
-                    if v != v2:
-                        changed = True
+        mismatched = {k:v for k, v in current.items() if params[k] != v}
+        if mismatched:
+            changed = True
     else:
         if current.items() < params.items():
             changed = False
+
     # if configs dont match and checkmode is off, complete the change
     if changed == True and not module.check_mode:
         result = client.secrets.azure.configure(tenant_id=tenant_id, subscription_id=subscription_id, client_id=client_id, client_secret=client_secret, mount_point=mount_point)

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+import json
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_azure_secret_engine_config
+version_added: "3.17.6"
+short_description: Hashicorp Vault azure secret engine config
+description:
+    - Module to configure an azure secret engine via variables or json file
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
+             is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
+             variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap, approle"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: to environment variable VAULT_USER
+    password:
+        description:
+            - password to login to vault.
+        default: to environment variable VAULT_PASSWORD
+    mount_point:
+        description:
+            - name of the secret engine mount name.
+        default: 'azure'
+    subscription_id:
+        description:
+            - azure SPN subscription id
+    tenant_id:
+        description:
+            - azure SPN tenant id
+    client_id:
+        description:
+            - azure SPN client id
+    client_secret:
+        description:
+            - azure SPN client secret
+    config_file:
+        description:
+            - alternate way to pass SPN vars. must be json object
+    environment:
+        description:
+            - azure environment. you probably do not want to change this
+        default: AzurePublicCloud
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_azure_secret_engine_config:
+        subscription_id: 1234
+        tenant_id: 5689-1234
+        tenant_id: 5689-1234
+        client_id: 1012-1234
+        client_secret: 1314-1234
+
+    - hashivault_azure_secret_engine_config:
+        config_file: /home/drewbuntu/azure-config.json
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['mount_point'] = dict(required=False, type='str', default='azure')
+    argspec['subscription_id'] = dict(required=False, type='str')
+    argspec['tenant_id'] = dict(required=False, type='str')
+    argspec['client_id'] = dict(required=False, type='str')
+    argspec['client_secret'] = dict(required=False, type='str')
+    argspec['environment'] = dict(required=False, type='str', default='AzurePublicCloud')
+    argspec['config_file'] = dict(required=False, type='str', default=None)
+    supports_check_mode=True
+    required_together=[['subscription_id', 'client_id', 'client_secret', 'tenant_id']]
+
+    module = hashivault_init(argspec, supports_check_mode, required_together)
+    result = hashivault_azure_secret_engine_config(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_azure_secret_engine_config(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    changed = True
+    config_file = params.get('config_file')
+    mount_point = params.get('mount_point')
+
+    # if config_file is set, set sub_id, ten_id, client_id, client_secret from file
+    # else set from passed args
+    if config_file:
+        config = json.loads(open(params.get('config_file'), 'r').read())
+        tenant_id = config.get('tenant_id')
+        subscription_id = config.get('subscription_id')
+        client_id = config.get('client_id')
+        client_secret = config.get('client_secret')       
+    else:
+        tenant_id = params.get('tenant_id')
+        subscription_id = params.get('subscription_id')
+        client_id = params.get('client_id')
+        client_secret = params.get('client_secret')
+
+    # check if engine is enabled
+    client.sys.list_auth_methods().keys()
+    if (mount_point + "/") not in client.sys.list_auth_methods().keys():
+         return {'failed': True, 'msg': 'auth backend is not enabled', 'rc': 1}
+    
+    # check if current config matches desired config values, if they match, set changed to false to prevent action
+    current = client.secrets.azure.read_config()
+    if current.items() < params.items(): 
+        changed = False
+
+    # if configs dont match and checkmode is off, complete the change
+    if changed == True and not module.check_mode:
+        result = client.secrets.azure.configure(tenant_id=tenant_id, subscription_id=subscription_id, client_id=client_id, client_secret=client_secret, mount_point=mount_point)
+    
+    return {'changed': changed}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+import json
+from ast import literal_eval
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_azure_secret_engine_role
+version_added: "3.17.6"
+short_description: Hashicorp Vault azure secret engine role
+description:
+    - Module to define a Azure role that vault can generate dynamic credentials for vault
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
+             is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
+             variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap, approle"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: to environment variable VAULT_USER
+    password:
+        description:
+            - password to login to vault.
+        default: to environment variable VAULT_PASSWORD
+    mount_point:
+        descrition:
+            - name of the secret engine mount name.
+        default: `azure`
+    name:
+        descrition:
+            - name of the role in vault
+    azure_role:
+        descrition:
+            - list of nested dicts filled with role content [{"role_name":"", "scope":""}]
+    azure_role_file:
+        descrition:
+            - file with a single dict, azure_role
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_azure_secret_engine_role:
+        name: contributor-role
+        azure_role: [{ "role_name": "Contributor","scope": "/subscriptions/sub1234"}]
+
+    - hashivault_azure_secret_engine_role:
+        name: contributor-role
+        azure_role_file: /users/dmullen/my-role-file.json
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    # argspec['state'] = dict(required=False, type='str', default='present', choices=['present', 'absent']) delete role is not supported at this time
+    argspec['name'] = dict(required=True, type='str')
+    argspec['azure_role'] = dict(required=False, type='str')
+    argspec['azure_role_file'] = dict(required=False, type='str')
+    argspec['mount_point'] = dict(required=False, type='str', default='azure')
+    supports_check_mode=True
+    mutually_exclusive=[['azure_role','azure_role_file']]
+
+    module = hashivault_init(argspec, supports_check_mode, mutually_exclusive)
+    result = hashivault_azure_secret_engine_role(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_azure_secret_engine_role(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    azure_role_file = params.get('azure_role_file')
+    mount_point = params.get('mount_point')
+    azure_role = params.get('azure_role')
+    name = params.get('name')
+    changed = False
+
+    # do not want a trailing slash in name
+    if name[-1] == '/':
+        name = name.strip('/')
+    if mount_point[-1]:
+        mount_point = mount_point.strip('/')
+
+    # if azure_role_file is set, set azure_role to contents
+    # else assume azure_role is set and use that value
+    if azure_role_file:
+        azure_role = json.loads(open(params.get('azure_role_file'), 'r').read())['azure_role']
+
+    # check if engine is enabled
+    if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
+        return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
+
+    # check if role exists or any at all
+    try:
+        existing_roles = client.secrets.azure.list_roles(mount_point=mount_point)
+        if name not in existing_roles['keys']:
+            changed = True
+    except:
+        changed = True
+
+    # azure_role comes from json which is assigned as a str object type, convert to py objs
+    azure_role = literal_eval(azure_role)
+    if not changed:
+        # check if role content == desired
+        current = client.secrets.aws.read_role(name=name,mount_point=mount_point)['data']['azure_roles']
+        caught = 0
+        for i in azure_role:
+            for i2 in current:
+                if i.items() <= i2.items():
+                    caught = caught + 1
+        if caught != len(azure_role) or caught != len(current):
+            changed = True
+
+    # make the changes!
+    if changed and not module.check_mode:
+        client.secrets.azure.create_or_update_role(name=name, azure_roles=azure_role)
+    
+    return {'changed': changed}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
@@ -58,17 +58,17 @@ options:
             - password to login to vault.
         default: to environment variable VAULT_PASSWORD
     mount_point:
-        descrition:
+        description:
             - name of the secret engine mount name.
-        default: `azure`
+        default: azure
     name:
-        descrition:
+        description:
             - name of the role in vault
     azure_role:
-        descrition:
+        description:
             - list of nested dicts filled with role content [{"role_name":"", "scope":""}]
     azure_role_file:
-        descrition:
+        description:
             - file with a single dict, azure_role
 '''
 EXAMPLES = '''

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -20,6 +20,7 @@ ansible-playbook -v test_lookup.yml
 ansible-playbook -v test_delete.yml
 ansible-playbook -v test_auth.yml
 ansible-playbook -v test_secret_list.yml
+ansible-playbook -vvv test_azure_config.yml
 ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -20,7 +20,7 @@ ansible-playbook -v test_lookup.yml
 ansible-playbook -v test_delete.yml
 ansible-playbook -v test_auth.yml
 ansible-playbook -v test_secret_list.yml
-ansible-playbook -vvv test_azure_config.yml
+ansible-playbook -v test_azure_config.yml
 ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -21,7 +21,7 @@ ansible-playbook -v test_delete.yml
 ansible-playbook -v test_auth.yml
 ansible-playbook -v test_secret_list.yml
 ansible-playbook -v test_azure_config.yml
-#ansible-playbook -v test_azure_role.yml cannot run without true azure connectivity
+# ansible-playbook -v test_azure_role.yml cannot run without true azure connectivity
 ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -21,6 +21,7 @@ ansible-playbook -v test_delete.yml
 ansible-playbook -v test_auth.yml
 ansible-playbook -v test_secret_list.yml
 ansible-playbook -v test_azure_config.yml
+#ansible-playbook -v test_azure_role.yml cannot run without true azure connectivity
 ansible-playbook -v test_policy.yml
 ansible-playbook -v test_status.yml
 ansible-playbook -v test_not_there.yml

--- a/functional/test_azure_config.yml
+++ b/functional/test_azure_config.yml
@@ -1,0 +1,58 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    subscription_id: test
+    client_id: values
+    client_secret: dont
+    tenant_id: matter
+  tasks:
+    - hashivault_secret_disable:
+        name: azure
+      failed_when: false
+         
+    - name: make sure test fails when no mount exists
+      hashivault_azure_secret_engine_config:
+        subscription_id: "{{ subscription_id }}"
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+      register: fail_config
+      failed_when: false
+
+    - assert: { that: "{{ fail_config.changed }} == False" }
+    
+    - hashivault_secret_enable:
+        name: azure
+        backend: azure
+         
+    - name: successfully enable mount
+      hashivault_azure_secret_engine_config:
+        subscription_id: "{{ subscription_id }}"
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+      register: success_config
+    
+    - assert: { that: "{{ success_config.changed }} == True" }
+
+    - name: attempt 2nd config with same values
+      hashivault_azure_secret_engine_config:
+        subscription_id: "{{ subscription_id }}"
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+      register: idem_config
+    
+    - assert: { that: "{{ idem_config.changed }} == False" }
+
+    - name: attempt 3rd config with different values
+      hashivault_azure_secret_engine_config:
+        subscription_id: blergh
+        client_id: flergh
+        client_secret: mlergh
+        tenant_id: splurgh
+      register: overwrite_config
+    
+    - assert: { that: "{{ overwrite_config.changed }} == True" }

--- a/functional/test_azure_role.yml
+++ b/functional/test_azure_role.yml
@@ -1,0 +1,70 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    subscription_id: "xyz"
+    client_id: ""
+    client_secret: ""
+    tenant_id: ""
+    azure_role1: [{ "role_name": "Contributor","scope": "/subscriptions/xyz"}]
+    azure_role2: [{ "role_name": "Contributor","scope": "/subscriptions/xyz"}, { "role_name": "Reader","scope": "/subscriptions/xyz"}]
+  tasks:
+    - hashivault_secret_disable:
+        name: azure
+      failed_when: false
+
+    - name: fail before mount is configured
+      hashivault_azure_secret_engine_role:
+        name: test
+        azure_role: "{{ azure_role1 }}"
+      failed_when: false
+      register: fail_config
+
+    - assert: { that: "{{ fail_config.changed }} == False" } # fail
+    
+    - name: enable azure secret engine
+      hashivault_secret_enable:
+        name: azure
+        backend: azure
+         
+    - name: configure azure mount
+      hashivault_azure_secret_engine_config:
+        subscription_id: "{{ subscription_id }}"
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+
+    - name: write 1 azure_role
+      hashivault_azure_secret_engine_role:
+        name: test
+        azure_role: "{{ azure_role1 }}"
+      register: success_write
+
+    - assert: { that: "{{ success_write.changed }} == True" } # changed
+
+    - name: idem same azure_role
+      hashivault_azure_secret_engine_role:
+        name: test
+        azure_role: "{{ azure_role1 }}"
+      register: idem_write
+
+    - assert: { that: "{{ idem_write.changed }} == False" } # not changed    
+
+    - name: overwrite existing
+      hashivault_azure_secret_engine_role:
+        name: test
+        azure_role: "{{ azure_role2 }}"
+      register: overwrite
+
+    - assert: { that: "{{ overwrite.changed }} == True" } # changed
+
+    # since we're doing dict compare, ensure that a dict with less obj
+    # correctly is overwritten
+    - name: ensure smaller azure_role successfully overwrites
+      hashivault_azure_secret_engine_role:
+        name: test
+        azure_role: "{{ azure_role1 }}"
+      register: overwrite_smaller
+
+    - assert: { that: "{{ overwrite_smaller.changed }} == True" } # changed


### PR DESCRIPTION
this PR allows passing AnsibleModule vars:
- `required_if`
- `required_together`
- `required_one_of`
- `mutually_exclusive`

more info can be found [here](http://mobygeek.net/blog/2016/02/16/ansible-module-development-parameters/)

this PR also creates a new ansible module `hashivault_azure_secret_engine_config` which takes azure SPN creds as an input from either yaml or as a json file and configures an `azure` secret engine.

this PR also creates a new ansible module `hashivault_azure_secret_engine_role` which defines azure roles in a vault azure secret engine for dynamic credentialing

**testing**
functional/test_azure_config.yml
functional/test_azure_role.yml <- disabled due to reliance on azure credentials


https://github.com/TerryHowe/ansible-modules-hashivault/issues/129