### PR TITLE
drewmullen/issue-129 azure auth method config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -232,8 +232,9 @@ Handle auth backends::
         - hashivault_auth_list:
           register: 'vault_auth_list'
         - block:
-          - hashivault_auth_enable:
-              name: "userpass"
+          - hashivault_auth_method:
+              method_type: "userpass"
+              state: "enabled"
             register: 'vault_auth_enable'
           when: "'userpass/' not in vault_auth_list.backends"
 

--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_auth_method
+version_added: "3.17.7"
+short_description: Hashicorp Vault auth module
+description:
+    - Module to enable or disable authentication ethods in Hashicorp Vault.
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
+             is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
+             variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap, approle"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: to environment variable VAULT_USER
+    password:
+        description:
+            - password to login to vault.
+        default: to environment variable VAULT_PASSWORD
+    method_type:
+        description:
+            - name of auth method. [required]
+    description:
+        description:
+            - description of authenticator
+    mount_point:
+        description:
+            - location where this auth_method will be mounted. also known as "path"
+    state:
+        description:
+            - should auth mount be enabled or disabled
+        default: enabled
+    config:
+        description:
+            - configuration set on auth method. expects a dict
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_auth_method:
+        method_type: userpass
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['method_type'] = dict(required=True, type='str')
+    argspec['description'] = dict(required=False, type='str')
+    argspec['state'] = dict(required=False, type='str', default='enabled', choices=['enabled','disabled','enable','disable'])
+    argspec['mount_point'] = dict(required=False, type='str', default=None)
+    argspec['config'] = dict(required=False, type='dict', default=None)
+    module = hashivault_init(argspec)
+    result = hashivault_auth_method(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_auth_method(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    method_type = params.get('method_type')
+    description = params.get('description')
+    mount_point = params.get('mount_point')
+    config = params.get('config')
+    state = params.get('state')
+    exists = False
+    changed = False
+
+    if mount_point == None:
+        mount_point = method_type
+
+    auth_methods = client.sys.list_auth_methods()
+    path = (mount_point or method_type) + u"/"
+
+    # is auth method enabled already?
+    if path in auth_methods['data'].keys():
+        exists = True
+
+    # if its off and we want it on
+    if (state == 'enabled' or state == 'enable') and exists == False:
+        changed = True
+    # if its on and we want it off
+    elif (state == 'disabled' or state == 'disable') and exists == True:
+        changed = True
+
+    if changed and not module.check_mode and (state == 'enabled' or state == 'enable'):
+        client.sys.enable_auth_method(method_type, description=description, path=mount_point, config=config)
+
+    if changed and not module.check_mode and (state == 'disabled' or state == 'disable'):
+        client.sys.disable_auth_method(path=mount_point)
+
+    return {'changed': changed}
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_azure_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_config.py
@@ -77,8 +77,12 @@ options:
             - alternate way to pass SPN vars. must be json object
     environment:
         description:
-            - azure environment. you probably do not want to change this
+            - azure environment. default is likely OK
         default: AzurePublicCloud
+    resource:
+        description:
+            - the azure AD resource the auth method accesses. default is likely OK
+        default: https://management.azure.com
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_azure_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_config.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+import json, sys
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_azure_auth_config
+version_added: "3.17.6"
+short_description: Hashicorp Vault azure auth config
+description:
+    - Module to configure an azure auth mount 
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
+             is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
+             variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap, approle"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: to environment variable VAULT_USER
+    password:
+        description:
+            - password to login to vault.
+        default: to environment variable VAULT_PASSWORD
+    mount_point:
+        description:
+            - name of the secret engine mount name.
+        default: azure
+    subscription_id:
+        description:
+            - azure SPN subscription id
+    tenant_id:
+        description:
+            - azure SPN tenant id
+    client_id:
+        description:
+            - azure SPN client id
+    client_secret:
+        description:
+            - azure SPN client secret
+    config_file:
+        description:
+            - alternate way to pass SPN vars. must be json object
+    environment:
+        description:
+            - azure environment. you probably do not want to change this
+        default: AzurePublicCloud
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_azure_auth_config:
+        subscription_id: 1234
+        tenant_id: 5689-1234
+        client_id: 1012-1234
+        client_secret: 1314-1234
+
+    - hashivault_azure_auth_config:
+        config_file: /home/drewbuntu/azure-auth-config.json
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['mount_point'] = dict(required=False, type='str', default='azure')
+    argspec['tenant_id'] = dict(required=False, type='str')
+    argspec['client_id'] = dict(required=False, type='str')
+    argspec['client_secret'] = dict(required=False, type='str')
+    argspec['environment'] = dict(required=False, type='str', default='AzurePublicCloud')
+    argspec['resource'] = dict(required=False, type='str', default='https://management.azure.com')
+    argspec['config_file'] = dict(required=False, type='str', default=None)
+    supports_check_mode=True
+    required_together=[['client_id', 'client_secret', 'tenant_id']]
+
+    module = hashivault_init(argspec, supports_check_mode, required_together)
+    result = hashivault_azure_auth_config(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_azure_auth_config(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    changed = False
+    config_file = params.get('config_file')
+    mount_point = params.get('mount_point')
+
+    # do not want a trailing slash in mount_point
+    if mount_point[-1]:
+        mount_point = mount_point.strip('/')
+
+    # if config_file is set, set sub_id, ten_id, client_id, client_secret from file
+    # else set from passed args
+    if config_file:
+        config = json.loads(open(params.get('config_file'), 'r').read())
+        tenant_id = config.get('tenant_id')
+        client_id = config.get('client_id')
+        client_secret = config.get('client_secret')       
+        resource = config.get('resource')       
+    else:
+        tenant_id = params.get('tenant_id')
+        client_id = params.get('client_id')
+        client_secret = params.get('client_secret')
+        resource = params.get('resource')       
+
+    # check if engine is enabled
+    if (mount_point + "/") not in client.sys.list_auth_methods()['data'].keys():
+        return {'failed': True, 'msg': 'auth mount is not enabled', 'rc': 1}
+
+    # check if any config exists
+    try:
+        current = client.auth.azure.read_config()
+    except:
+        changed = True
+
+    # check if current config matches desired config values, if they dont match, set changed true
+    if changed == False:
+        mismatched = {k:v for k, v in current.items() if params[k] != v}
+        if mismatched:
+            changed = True
+
+    # if configs dont match and checkmode is off, complete the change
+    if changed == True and not module.check_mode:
+        result = client.auth.azure.configure(tenant_id=tenant_id, client_id=client_id, client_secret=client_secret, resource=resource, mount_point=mount_point)
+    
+    return {'changed': changed}
+
+
+if __name__ == '__main__':
+    main()

--- a/ansible/modules/hashivault/hashivault_azure_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_config.py
@@ -9,7 +9,7 @@ ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 
 DOCUMENTATION = '''
 ---
 module: hashivault_azure_auth_config
-version_added: "3.17.6"
+version_added: "3.17.7"
 short_description: Hashicorp Vault azure auth config
 description:
     - Module to configure an azure auth mount 

--- a/ansible/modules/hashivault/hashivault_azure_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_role.py
@@ -96,18 +96,21 @@ options:
             - The list of scale set names that the login is restricted to.
     role_file:
         description:
-            - file with a single dict, pass all variables except name in this instead of ansible yaml
+            - file with a json object containing play parameters. pass all params but name, state, mount_point which stay in the ansible play
 '''
 EXAMPLES = '''
 ---
 - hosts: localhost
   tasks:
-    - hashivault_azure_auth_role:
-        name: contributor-role
-        
+      hashivault_azure_auth_role:
+        name: "test"
+        policies: ["test"]
+        bound_subscription_ids: ["6a1d5988-5917-4221-b224-904cd7e24a25"]
+        num_uses: 3
 
     - hashivault_azure_auth_role:
-        name: contributor-role
+        name: test
+        role_file: /users/drewbuntu/my-auth-role.json
 '''
 
 
@@ -130,7 +133,7 @@ def main():
     argspec['num_uses'] = dict(required=False, type='int', default=0)
 
     supports_check_mode=True
-    required_one_of=[['bound_service_principal_ids', 'bound_group_ids', 'bound_locations', 'bound_subscription_ids', 'bound_resource_groups', 'bound_scale_sets', 'role_file']]
+    required_one_of=[['bound_service_principal_ids', 'bound_group_ids', 'bound_locations', 'bound_subscription_ids', 'bound_resource_groups', 'bound_scale_sets', 'role_file', 'state']]
 
     module = hashivault_init(argspec, supports_check_mode, required_one_of)
     result = hashivault_azure_auth_role(module)
@@ -149,10 +152,7 @@ def hashivault_azure_auth_role(module):
     name = params.get('name')
     state = params.get('state')
     desired_state = dict()
-
-    # grab from file
-
-
+    exists = False
     changed = False
 
     # do not want a trailing slash in name
@@ -161,13 +161,10 @@ def hashivault_azure_auth_role(module):
     if mount_point[-1]:
         mount_point = mount_point.strip('/')
 
-    # input validation required for policies var?
-
     # if azure_role_file is set, set azure_role to contents
     # else assume azure_role is set and use that value
     if role_file:
         desired_state = json.loads(open(params.get('role_file'), 'r').read())
-        print(desired_state)
     else:
         desired_state['policies'] = params.get('policies')
         desired_state['ttl'] = params.get('token_ttl')
@@ -189,50 +186,34 @@ def hashivault_azure_auth_role(module):
     # check if role exists
     try:
         existing_roles = client.auth.azure.list_roles(mount_point=mount_point)
-        if name not in existing_roles['keys']:
-            # some roles exist but not this one
-            changed = True
+        if name in existing_roles['keys']:
+            # this role exists
+            exists = True
     except:
         # no roles exist yet
+        pass
+
+    if not exists and state == 'present':
         changed = True
 
     # compare current_state to desired_state
-    if not changed:
+    if exists and state == 'present' and not changed:
         current_state = client.auth.azure.read_role(name=name)   
         for k, v in desired_state.items():
-            print("desired ", k, " ", v, " type: ", type(v))
-            print("current_state ", k, " ", current_state[k], " type: ", type(current_state[k]))
             if v != current_state[k]:
                 changed = True
-                print('FIRE ')
-        
-
+    elif exists and state == 'absent':
+        changed = True
+    
     # make the changes!
     # NOTE: bound_location is paseed. will need to be changed eventually
     # https://github.com/hvac/hvac/issues/451
-    if changed and not module.check_mode:
-        result = client.auth.azure.create_role(name=name, mount_point=mount_point, **desired_state)
-        # ttl=token_ttl, max_ttl=token_max_ttl, 
-        #     period=token_period, bound_service_principal_ids=bound_service_principal_ids, bound_group_ids=bound_group_ids, bound_location=bound_locations, 
-        #     bound_subscription_ids=bound_subscription_ids, bound_resource_groups=bound_resource_groups, bound_scale_sets=bound_scale_sets)
-
-    # # azure_role comes from json which is assigned as a str object type, convert to py objs
-    # azure_role = literal_eval(azure_role)
-    # if not changed:
-    #     # check if role content == desired
-    #     current = client.secrets.aws.read_role(name=name,mount_point=mount_point)['data']['azure_roles']
-    #     caught = 0
-    #     for i in azure_role:
-    #         for i2 in current:
-    #             if i.items() <= i2.items():
-    #                 caught = caught + 1
-    #     if caught != len(azure_role) or caught != len(current):
-    #         changed = True
-
-    # # make the changes!
-    # if changed and not module.check_mode:
-    #     client.secrets.azure.create_or_update_role(name=name, azure_roles=azure_role)
+    if changed and state == 'present' and not module.check_mode:
+        client.auth.azure.create_role(name=name, mount_point=mount_point, **desired_state)
     
+    elif changed and state == 'absent' and not module.check_mode:
+        client.auth.azure.delete_role(name=name, mount_point=mount_point)
+
     return {'changed': changed}
 
 

--- a/ansible/modules/hashivault/hashivault_azure_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_role.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+import json
+from ast import literal_eval
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_azure_auth_role
+version_added: "3.17.6"
+short_description: Hashicorp Vault azure secret engine role
+description:
+    - Module to define a Azure role that vault can generate dynamic credentials for vault
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
+             is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
+             variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap, approle"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: to environment variable VAULT_USER
+    password:
+        description:
+            - password to login to vault.
+        default: to environment variable VAULT_PASSWORD
+    mount_point:
+        description:
+            - name of the secret engine mount name.
+        default: azure
+    name:
+        description:
+            - name of the role in vault
+    policies:
+        description:
+            - name of policies in vault to assign to role
+    token_ttl:
+        description:
+            - The TTL period of tokens issued using this role in seconds.
+    token_max_ttl:
+        description:
+            - The maximum allowed lifetime of tokens issued in seconds using this role.
+    token_period:
+        description:
+            - If set, indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this parameter.
+    bound_service_principal_ids:
+        description:
+            - The list of Service Principal IDs that login is restricted to.
+    bound_group_ids:
+        description:
+            - The list of group ids that login is restricted to.
+    bound_locations:
+        description:
+            - The list of locations that login is restricted to.
+    bound_subscription_ids:
+        description:
+            - The list of subscription IDs that login is restricted to.
+    bound_resource_groups:
+        description:
+            - The list of resource groups that login is restricted to.
+    bound_scale_sets:
+        description:
+            - The list of scale set names that the login is restricted to.
+    role_file:
+        description:
+            - file with a single dict, pass all variables except name in this instead of ansible yaml
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_azure_auth_role:
+        name: contributor-role
+        
+
+    - hashivault_azure_auth_role:
+        name: contributor-role
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['name'] = dict(required=True, type='str')
+    argspec['state'] = dict(required=False, type='str', default='present', choices=['present', 'absent'])
+    argspec['role_file'] = dict(required=False, type='str')
+    argspec['policies'] = dict(required=False, type='list')
+    argspec['mount_point'] = dict(required=False, type='str', default='azure')
+    argspec['token_ttl'] = dict(required=False, type='int', default=0)
+    argspec['token_max_ttl'] = dict(required=False, type='int', default=0)
+    argspec['token_period'] = dict(required=False, type='int', default=0)
+    argspec['bound_service_principal_ids'] = dict(required=False, type='list', default=[])
+    argspec['bound_group_ids'] = dict(required=False, type='list', default=[])
+    argspec['bound_locations'] = dict(required=False, type='list', default=[])
+    argspec['bound_subscription_ids'] = dict(required=False, type='list', default=[])
+    argspec['bound_resource_groups'] = dict(required=False, type='list', default=[])
+    argspec['bound_scale_sets'] = dict(required=False, type='list', default=[])
+    argspec['num_uses'] = dict(required=False, type='int', default=0)
+
+    supports_check_mode=True
+    required_one_of=[['bound_service_principal_ids', 'bound_group_ids', 'bound_locations', 'bound_subscription_ids', 'bound_resource_groups', 'bound_scale_sets', 'role_file']]
+
+    module = hashivault_init(argspec, supports_check_mode, required_one_of)
+    result = hashivault_azure_auth_role(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_azure_auth_role(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    mount_point = params.get('mount_point')
+    role_file = params.get('role_file')
+    name = params.get('name')
+    state = params.get('state')
+    desired_state = dict()
+
+    # grab from file
+
+
+    changed = False
+
+    # do not want a trailing slash in name
+    if name[-1] == '/':
+        name = name.strip('/')
+    if mount_point[-1]:
+        mount_point = mount_point.strip('/')
+
+    # input validation required for policies var?
+
+    # if azure_role_file is set, set azure_role to contents
+    # else assume azure_role is set and use that value
+    if role_file:
+        desired_state = json.loads(open(params.get('role_file'), 'r').read())
+        print(desired_state)
+    else:
+        desired_state['policies'] = params.get('policies')
+        desired_state['ttl'] = params.get('token_ttl')
+        desired_state['max_ttl'] = params.get('token_max_ttl')
+        desired_state['period'] = params.get('token_period')
+        desired_state['bound_service_principal_ids'] = params.get('bound_service_principal_ids')
+        desired_state['bound_group_ids'] = params.get('bound_group_ids')
+        desired_state['bound_locations'] = params.get('bound_locations')
+        desired_state['bound_subscription_ids'] = params.get('bound_subscription_ids')
+        desired_state['bound_resource_groups'] = params.get('bound_resource_groups')
+        desired_state['bound_scale_sets'] = params.get('bound_scale_sets')
+        desired_state['num_uses'] = params.get('num_uses')
+
+
+    # check if engine is enabled
+    if (mount_point + "/") not in client.sys.list_auth_methods()['data'].keys():
+        return {'failed': True, 'msg': 'auth method is not enabled', 'rc': 1}
+
+    # check if role exists
+    try:
+        existing_roles = client.auth.azure.list_roles(mount_point=mount_point)
+        if name not in existing_roles['keys']:
+            # some roles exist but not this one
+            changed = True
+    except:
+        # no roles exist yet
+        changed = True
+
+    # compare current_state to desired_state
+    if not changed:
+        current_state = client.auth.azure.read_role(name=name)   
+        for k, v in desired_state.items():
+            print("desired ", k, " ", v, " type: ", type(v))
+            print("current_state ", k, " ", current_state[k], " type: ", type(current_state[k]))
+            if v != current_state[k]:
+                changed = True
+                print('FIRE ')
+        
+
+    # make the changes!
+    # NOTE: bound_location is paseed. will need to be changed eventually
+    # https://github.com/hvac/hvac/issues/451
+    if changed and not module.check_mode:
+        result = client.auth.azure.create_role(name=name, mount_point=mount_point, **desired_state)
+        # ttl=token_ttl, max_ttl=token_max_ttl, 
+        #     period=token_period, bound_service_principal_ids=bound_service_principal_ids, bound_group_ids=bound_group_ids, bound_location=bound_locations, 
+        #     bound_subscription_ids=bound_subscription_ids, bound_resource_groups=bound_resource_groups, bound_scale_sets=bound_scale_sets)
+
+    # # azure_role comes from json which is assigned as a str object type, convert to py objs
+    # azure_role = literal_eval(azure_role)
+    # if not changed:
+    #     # check if role content == desired
+    #     current = client.secrets.aws.read_role(name=name,mount_point=mount_point)['data']['azure_roles']
+    #     caught = 0
+    #     for i in azure_role:
+    #         for i2 in current:
+    #             if i.items() <= i2.items():
+    #                 caught = caught + 1
+    #     if caught != len(azure_role) or caught != len(current):
+    #         changed = True
+
+    # # make the changes!
+    # if changed and not module.check_mode:
+    #     client.secrets.azure.create_or_update_role(name=name, azure_roles=azure_role)
+    
+    return {'changed': changed}
+
+
+if __name__ == '__main__':
+    main()

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -19,6 +19,8 @@ ansible-playbook -v test_list.yml
 ansible-playbook -v test_lookup.yml
 ansible-playbook -v test_delete.yml
 ansible-playbook -v test_auth.yml
+ansible-playbook -v test_auth_method.yml
+ansible-playbook -v test_azure_auth_config.yml
 ansible-playbook -v test_secret_list.yml
 ansible-playbook -v test_azure_config.yml
 # ansible-playbook -v test_azure_role.yml cannot run without true azure connectivity

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -21,6 +21,7 @@ ansible-playbook -v test_delete.yml
 ansible-playbook -v test_auth.yml
 ansible-playbook -v test_auth_method.yml
 ansible-playbook -v test_azure_auth_config.yml
+# ansible-playbook -v test_azure_auth_role.yml wont work till hvac 9.2, issues/451 
 ansible-playbook -v test_secret_list.yml
 ansible-playbook -v test_azure_config.yml
 # ansible-playbook -v test_azure_role.yml cannot run without true azure connectivity

--- a/functional/test_auth_method.yml
+++ b/functional/test_auth_method.yml
@@ -1,0 +1,29 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - hashivault_auth_method:
+        method_type: azure
+        state: disabled
+
+    - hashivault_auth_method:
+        method_type: azure
+        state: disabled
+      register: disable_idem
+
+    - assert: { that: "{{ disable_idem.changed }} == False" }
+    
+    - name: enable azure secret engine
+      hashivault_auth_method:
+        method_type: azure
+      register: enable_chg
+
+    - assert: { that: "{{ enable_chg.changed }} == True" }
+
+    - hashivault_auth_method:
+        method_type: azure
+        state: disabled
+      register: disable_chg
+
+    - assert: { that: "{{ disable_chg.changed }} == True" }

--- a/functional/test_azure_auth_config.yml
+++ b/functional/test_azure_auth_config.yml
@@ -1,0 +1,54 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    client_id: values
+    client_secret: dont
+    tenant_id: matter
+  tasks:
+    - hashivault_auth_method:
+        method_type: azure
+        state: disabled
+      failed_when: false
+         
+    - name: make sure test fails when no mount exists
+      hashivault_azure_auth_config:
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+      register: fail_config
+      failed_when: false
+
+    - assert: { that: "{{ fail_config.changed }} == False" }
+    
+    - name: enable azure auth method 
+      hashivault_auth_method:
+        method_type: azure
+         
+    - name: successfully configure method
+      hashivault_azure_auth_config:
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+      register: success_config
+
+    - assert: { that: "{{ success_config.changed }} == True" }
+
+    - name: attempt 2nd config with same values
+      hashivault_azure_auth_config:
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+      register: idem_config
+    
+    - assert: { that: "{{ idem_config.changed }} == False" }
+
+    - name: attempt 3rd config with different values
+      hashivault_azure_auth_config:
+        client_id: flergh
+        client_secret: mlergh
+        tenant_id: splurgh
+      register: overwrite_config
+    
+    - assert: { that: "{{ overwrite_config.changed }} == True" }

--- a/functional/test_azure_auth_role.yml
+++ b/functional/test_azure_auth_role.yml
@@ -1,0 +1,43 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    client_id: values
+    client_secret: dont
+    tenant_id: matter
+  tasks:
+    - hashivault_auth_method:
+        method_type: azure
+        state: disabled
+      failed_when: false
+         
+    - name: enable azure secret engine
+      hashivault_auth_method:
+        method_type: azure
+         
+    - name: successfully configure mount
+      hashivault_azure_auth_config:
+        client_id: "{{ client_id }}"
+        client_secret: "{{ client_secret }}"
+        tenant_id: "{{ tenant_id }}"
+
+    - name: create 1st role
+      hashivault_azure_auth_role:
+        name: "test"
+        policies: ["test"]
+        bound_subscription_ids: ["6a1d5988-5917-4221-b224-904cd7e24a25"]
+        num_uses: 3
+      register: success_config
+    
+    - assert: { that: "{{ success_config.changed }} == True" }
+
+    - name: idempotently create role
+      hashivault_azure_auth_role:
+        name: "test"
+        policies: ["test"]
+        bound_subscription_ids: ["6a1d5988-5917-4221-b224-904cd7e24a25"]
+        num_uses: 3
+      register: idem_config
+    
+    - assert: { that: "{{ idem_config.changed }} == False" }

--- a/functional/test_azure_auth_role.yml
+++ b/functional/test_azure_auth_role.yml
@@ -41,3 +41,11 @@
       register: idem_config
     
     - assert: { that: "{{ idem_config.changed }} == False" }
+
+    - name: delete role
+      hashivault_azure_auth_role:
+        name: test
+        state: absent
+      register: del_config
+    
+    - assert: { that: "{{ del_config.changed }} == True" }


### PR DESCRIPTION
This PR includes 3 features

new auth management module: `hashivault_auth_method` https://github.com/TerryHowe/ansible-modules-hashivault/issues/131
allows you to enable, disable, and **configure** an auth method in vault

new module for configuring the azure auth method: `hashivault_azure_auth_config` https://github.com/TerryHowe/ansible-modules-hashivault/issues/129
allows you idempotently configure the azure/config. sets reasonable defaults for `resource` and `environment`. allows you to pass variables in a `config_file`

new module for creating azure auth roles: `hashivault_azure_auth_role` allows you to idempotently configure `auth/azure/role/<name>`. allows you to pass variables in `role_file`.

**NOTE**: `hashivault_azure_auth_role` will not function correctly until hvac 9.2 is released. PR has already been merged and changes have been tested against this new module. https://github.com/hvac/hvac/issues/451 https://github.com/hvac/hvac/pull/448 . tests have been disabled for the time being 