### PR TITLE
provide module to manage namespaces (ent only)

### DIFF
--- a/ansible/modules/hashivault/hashivault_namespace.py
+++ b/ansible/modules/hashivault/hashivault_namespace.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+
+DEFAULT_TTL = 2764800
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_namespace
+version_added: "4.0.1"
+short_description: Hashicorp Vault create / delete namespaces
+description:
+    - Module to create or delete Hashicorp Vault namespaces (enterprise only)
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
+             is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
+             variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    authtype:
+        description:
+            - "authentication type to use: token, userpass, github, ldap, approle"
+        default: token
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: to environment variable VAULT_USER
+    password:
+        description:
+            - password to login to vault.
+        default: to environment variable VAULT_PASSWORD
+    name:
+        description:
+            - name of the namespace
+    state:
+        description:
+            - state of secret backend. choices: present, disabled
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_namespace:
+        name: teama
+
+    - name: "create a child namespace 'team1' in 'teama' ns: teama/team1"
+      hashivault_namespace:
+        name: team1
+        namespace: teama
+'''
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['name'] = dict(required=True, type='str')
+    argspec['state'] = dict(required=False, type='str', choices=['present', 'absent'], default='present')
+    module = hashivault_init(argspec)
+    result = hashivault_secret_engine(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_secret_engine(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    name = params.get('name')
+    state = params.get('state')
+    current_state = dict()
+    exists = False
+    changed = False
+
+    try:
+        # does the ns exist already?
+        current_state = client.sys.list_namespaces()['data']['keys']
+        if (name + '/') in current_state:
+            exists = True
+    except Exception:
+        # doesnt exist
+        pass
+    
+    # doesnt exist and should or does exist and shouldnt
+    if (exists and state == 'absent') or (not exists and state == 'present'):
+        changed = True
+
+    # make changes!
+    
+    # doesnt exist and should
+    if changed and not exists and state == 'present' and not module.check_mode:
+        client.sys.create_namespace(path=name)
+    
+    # exists and shouldnt    
+    elif changed and (state == 'absent' or state == 'disabled') and not module.check_mode:
+        client.sys.delete_namespace(path=name)
+
+    return {'changed': changed}
+
+
+if __name__ == '__main__':
+    main()

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -24,6 +24,7 @@ ansible-playbook -v test_auth_method.yml
 ansible-playbook -v test_azure_auth_config.yml
 ansible-playbook -v test_azure_auth_role.yml
 ansible-playbook -v test_secret_list.yml
+# ansible-playbook -v test_namespace.yml cannot run without enterprise 
 # ansible-playbook -v test_db_config.yml cannot run without true db connectivity
 # ansible-playbook -v test_db_role.yml cannot run without true db connectivity
 ansible-playbook -v test_azure_config.yml

--- a/functional/test_namespace.yml
+++ b/functional/test_namespace.yml
@@ -1,0 +1,86 @@
+---
+- hosts: localhost
+  connection: localhost
+  tasks:
+    
+    - hashivault_namespace:
+        name: hvtest
+        state: absent
+
+    - hashivault_namespace:
+        name: hvtest
+      register: first_create
+
+    - assert: { that: "{{first_create.changed}} == True" }
+
+    - hashivault_namespace:
+        name: hvtest
+      register: idem_create
+
+    - assert: { that: "{{idem_create.changed}} == False" }
+
+    - hashivault_namespace:
+        name: child
+        namespace: hvtest
+      register: second_create
+
+    - assert: { that: "{{second_create.changed}} == True" }
+    
+    - hashivault_namespace:
+        name: child
+        namespace: hvtest
+      register: second_idem_create
+
+    - assert: { that: "{{second_idem_create.changed}} == False" }
+
+    - hashivault_namespace:
+        name: child2
+        namespace: hvtest/child
+      register: third_create
+
+    - assert: { that: "{{third_create.changed}} == True" }
+
+    - hashivault_namespace:
+        name: child2
+        namespace: hvtest/child
+      register: third_idem_create
+
+    - assert: { that: "{{third_idem_create.changed}} == False" }
+
+    - hashivault_namespace:
+        name: hvtest
+        state: absent
+      register: delete_fail
+      failed_when: False
+    - assert: { that: "{{delete_fail.rc}} != 0" }
+
+
+    - hashivault_namespace:
+        name: child2
+        namespace: hvtest/child
+        state: absent
+      register: delete_one
+
+    - assert: { that: "{{delete_one.changed}} == True" }
+
+    - hashivault_namespace:
+        name: child
+        namespace: hvtest
+        state: absent
+      register: delete_two
+
+    - assert: { that: "{{delete_two.changed}} == True" }
+
+    - hashivault_namespace:
+        name: hvtest
+        state: absent
+      register: delete_three
+
+    - assert: { that: "{{delete_three.changed}} == True" }
+
+    - hashivault_namespace:
+        name: hvtest
+        state: absent
+      register: delete_idem
+
+    - assert: { that: "{{delete_idem.changed}} == False" }


### PR DESCRIPTION
create and delete namespaces in vault. this is an enterprise only feature (quite a good one too!)

tests are written and included but not enabled because this repo test suite doesnt use enterprise. we can start using enterprise trial at some point. this url can be modified for newer versions: https://s3-us-west-2.amazonaws.com/hc-enterprise-binaries/vault/ent/1.1.3/vault-enterprise_1.1.3%2Bent_darwin_amd64.zip

we started using that in hvac a few weeks back: https://github.com/hvac/hvac/pull/478
