### PR TITLE
Fix some cases where casting raise exception

### DIFF
--- a/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
@@ -182,8 +182,10 @@ def hashivault_db_secret_engine_config(module):
         for k, v in current_state['data'].items():
             # connection_url is passed as a nested item
             if k == 'connection_details':
-                if len(set(v.items()) - set(params.get('connection_details').items())):
-                    changed = True
+                for i in params.get('connection_details'):
+                    if params.get('connection_details')[i] != v[i]:
+                        changed = True
+                        break
             else:
                 if v != desired_state[k]:
                     changed = True


### PR DESCRIPTION
Signed-off-by: Damien Goldenberg <damdam.gold@gmail.com>

When in the `connection_details` there is a nested list there is an exception: `Exception: unhashable type: 'list'`
Maybe there is another way to avoid this problem