### PR TITLE
fix idempotence check for secret_engine when version 2 is passed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,25 +229,10 @@ Handle auth backends::
     ---
     - hosts: localhost
       tasks:
-        - hashivault_auth_list:
-          register: 'vault_auth_list'
-        - block:
-          - hashivault_auth_method:
-              method_type: "userpass"
-              state: "enabled"
-            register: 'vault_auth_enable'
-          when: "'userpass/' not in vault_auth_list.backends"
+        - hashivault_auth_method:
+            method_type: "userpass"
+            state: "enabled"
 
-Tune auth backends::
-
-    ---
-    - hosts: localhost
-      tasks:
-        - name: Tune ephermal secret store
-          hashivault_mount_tune:
-            mount_point: ephemeral
-            default_lease_ttl: 3600
-            max_lease_ttl: 8600
 
 Audit Backends
 --------------
@@ -288,14 +273,16 @@ Secret Backends
 Enable and disable various secret backends::
 
     ---
-    - hashivault_secret_list:
-      register: 'hashivault_secret_list'
-    - hashivault_secret_enable:
-        name: "ephemeral"
-        backend: "generic"
-    - hashivault_secret_disable:
-        name: "ephemeral"
-        backend: "generic"
+    - hashivault_secret_engine:
+        name: secret
+        backend: kv
+        options:
+          version: 2
+        config:
+          default_lease_ttl: 1500
+    - hashivault_secret_engine:
+        name: secret
+        state: absent
 
 Token Manipulation
 ------------------

--- a/ansible/modules/hashivault/_hashivault_mount_tune.py
+++ b/ansible/modules/hashivault/_hashivault_mount_tune.py
@@ -4,14 +4,14 @@ from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
 from ansible.module_utils.hashivault import hashiwrapper
 
-ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+ANSIBLE_METADATA = {'status': ['deprecated'], 'supported_by': 'community', 'version': '1.1'}
 DOCUMENTATION = '''
 ---
 module: hashivault_mount_tune
 version_added: "3.7.0"
 short_description: Hashicorp Vault tune backend
 description:
-    - Module to enable tuning of backends in HashiCorp Vault.
+    - Module to enable tuning of backends in HashiCorp Vault. use hashivault_secret_engine instead
 options:
     url:
         description:

--- a/ansible/modules/hashivault/hashivault_secret_engine.py
+++ b/ansible/modules/hashivault/hashivault_secret_engine.py
@@ -138,6 +138,7 @@ def hashivault_secret_engine(module):
             config['max_lease_ttl'] = DEFAULT_TTL
         if 'force_no_cache' not in config:
             config['force_no_cache'] = False
+        options['version'] = str(options['version'])
 
         for k, v in current_state.items(): #while not changed?
             # options is passed in ['data'] but set outside 'config':{}, manually check

--- a/functional/test_kv2.yml
+++ b/functional/test_kv2.yml
@@ -6,8 +6,9 @@
       hashivault_secret_disable:
         name: "kv2"
       failed_when: False
+
     - name: Enable kv2 secret store
-      hashivault_secret_enable:
+      hashivault_secret_engine:
         name: "kv2"
         backend: "kv"
         options:
@@ -17,7 +18,7 @@
     - assert: { that: "{{vault_secret_enable.rc}} == 0" }
 
     - name: Enable same secret store again and check it doesn't fail
-      hashivault_secret_enable:
+      hashivault_secret_engine:
         name: "kv2"
         backend: "kv"
         options:

--- a/functional/test_kv2.yml
+++ b/functional/test_kv2.yml
@@ -3,8 +3,9 @@
   gather_facts: no
   tasks:
     - name: Make sure kv2 secret store is disabled
-      hashivault_secret_disable:
+      hashivault_secret_engine:
         name: "kv2"
+        state: absent
       failed_when: False
 
     - name: Enable kv2 secret store
@@ -89,26 +90,35 @@
     - assert: { that: "'{{vault_read.msg}}' == 'Secret secret/kv2/name is not in vault'" }
 
     - name: Tune kv2 secret store
-      hashivault_mount_tune:
-        mount_point: kv2
-        default_lease_ttl: 3600
-        max_lease_ttl: 8600
+      hashivault_secret_engine:
+        backend: kv
+        name: kv2
+        options:
+          version: 2
+        config:
+          default_lease_ttl: 3600
+          max_lease_ttl: 8600
       register: vault_tune
     - assert: { that: "{{ vault_tune.changed }} == True" }
     - assert: { that: "{{ vault_tune.rc }} == 0" }
 
     - name: Idempotent tuning kv2 secret store
-      hashivault_mount_tune:
-        mount_point: kv2
-        default_lease_ttl: 3600
-        max_lease_ttl: 8600
+      hashivault_secret_engine:
+        backend: kv
+        name: kv2
+        options:
+          version: 2
+        config:
+          default_lease_ttl: 3600
+          max_lease_ttl: 8600
       register: vault_tune
     - assert: { that: "{{ vault_tune.changed }} == False" }
     - assert: { that: "{{ vault_tune.rc }} == 0" }
 
     - name: Disable kv2 secret store
-      hashivault_secret_disable:
+      hashivault_secret_engine:
         name: "kv2"
+        state: absent
       register: 'vault_secret_disable'
     - assert: { that: "{{vault_secret_enable.changed}} == True" }
     - assert: { that: "{{vault_secret_enable.rc}} == 0" }


### PR DESCRIPTION
fixes: https://github.com/TerryHowe/ansible-modules-hashivault/issues/158

options['version'] accepts an int, cast to a string to ensure idempotence checks work

test wasnt failing because was using deprecated module `hashivault_secret_enable`, resolved