### PR TITLE
fix db idempotency check

### DIFF
--- a/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
@@ -182,10 +182,10 @@ def hashivault_db_secret_engine_config(module):
         for k, v in current_state['data'].items():
             # connection_url is passed as a nested item
             if k == 'connection_details':
-                for i in params.get('connection_details'):
-                    if params.get('connection_details')[i] != v[i]:
-                        changed = True
-                        break
+                if v['username'] != desired_state['username']:
+                    changed = True
+                if v['connection_url'] != desired_state['connection_url']:
+                    changed = True
             else:
                 if v != desired_state[k]:
                     changed = True


### PR DESCRIPTION
current state v desired state are not compared properly. idempotent runs of this play are failling:

CURRENT:
```
[
 ('connection_url', 'postgresql://{{username}}:{{password}}@'),
 ('root_credentials_rotate_statements', []),
 ('username', 'user@')
]
```
vs

DESIRED:
```
[
 ('username', 'user@),
 ('connection_url', 'postgresql://{{username}}:{{password}}@')
]
```

changing to explicitly check instead