### PR TITLE
Check mode fix

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -113,12 +113,16 @@ def hashivault_auth_method(module):
     if mount_point == None:
         mount_point = method_type
 
-    auth_methods = client.sys.list_auth_methods()
-    path = (mount_point or method_type) + u"/"
+    try:
+        auth_methods = client.sys.list_auth_methods()
+        path = (mount_point or method_type) + u"/"
 
-    # Is auth method enabled already?
-    if path in auth_methods['data'].keys():
-        exists = True
+        # Is auth method enabled already?
+        if path in auth_methods['data'].keys():
+            exists = True
+    except:
+        if module.check_mode:
+            changed = True
 
     # if its off and we want it on
     if (state == 'enabled' or state == 'enable') and exists == False:

--- a/ansible/modules/hashivault/hashivault_azure_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_role.py
@@ -180,8 +180,12 @@ def hashivault_azure_auth_role(module):
 
 
     # check if engine is enabled
-    if (mount_point + "/") not in client.sys.list_auth_methods()['data'].keys():
-        return {'failed': True, 'msg': 'auth method is not enabled', 'rc': 1}
+    try:
+        if (mount_point + "/") not in client.sys.list_auth_methods()['data'].keys():
+            return {'failed': True, 'msg': 'auth method is not enabled', 'rc': 1}
+    except:
+        if module.check_mode:
+            changed = True
 
     # check if role exists
     try:

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -123,6 +123,7 @@ def hashivault_azure_secret_engine_config(module):
     config_file = params.get('config_file')
     mount_point = params.get('mount_point')
     desired_state = dict()
+    current_state = dict()
 
     # do not want a trailing slash in mount_point
     if mount_point[-1]:
@@ -142,11 +143,19 @@ def hashivault_azure_secret_engine_config(module):
         desired_state['environment'] = params.get('environment')    
 
     # check if engine is enabled
-    if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
-        return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
-    
+    try:
+        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
+            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
+    except:
+        if module.check_mode:
+            changed = True
+
     # check if current config matches desired config values, if they match, set changed to false to prevent action
-    current_state = client.secrets.azure.read_config()
+    try:
+        current_state = client.secrets.azure.read_config()
+    except:
+        changed = True
+
     for k, v in current_state.items():
         if v != desired_state[k]:
             changed = True
@@ -154,7 +163,7 @@ def hashivault_azure_secret_engine_config(module):
     # if configs dont match and checkmode is off, complete the change
     if changed == True and not module.check_mode:
         result = client.secrets.azure.configure(mount_point=mount_point, **desired_state)
-    
+
     return {'changed': changed}
 
 

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
@@ -124,8 +124,12 @@ def hashivault_azure_secret_engine_role(module):
         azure_role = json.loads(open(params.get('azure_role_file'), 'r').read())['azure_role']
 
     # check if engine is enabled
-    if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
-        return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
+    try:
+        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
+            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
+    except:
+        if module.check_mode:
+            changed = True
 
     # check if role exists or any at all
     try:

--- a/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
@@ -148,7 +148,7 @@ def hashivault_db_secret_engine_config(module):
     # if config_file is set value from file
     # else set from passed args
     if config_file:
-        desired_state = json.loads(open(params.get('config_file'), 'r').read())    
+        desired_state = json.loads(open(params.get('config_file'), 'r').read())
     else:
         desired_state['plugin_name'] = params.get('plugin_name')
         desired_state['allowed_roles'] = params.get('allowed_roles')
@@ -163,8 +163,12 @@ def hashivault_db_secret_engine_config(module):
         desired_state['root_credentials_rotate_statements'] = []
 
     # check if engine is enabled
-    if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
-        return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
+    try:
+        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
+            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
+    except:
+        if module.check_mode:
+            changed = True
 
     # check if any config exists
     try:
@@ -173,7 +177,7 @@ def hashivault_db_secret_engine_config(module):
     except Exception:
         # does not exist
         pass
-    
+
     if (exists and state == 'absent') or (not exists and state == 'present'):
         changed = True
 

--- a/ansible/modules/hashivault/hashivault_policy_set_from_file.py
+++ b/ansible/modules/hashivault/hashivault_policy_set_from_file.py
@@ -90,19 +90,27 @@ def hashivault_policy_set_from_file(module):
     client = hashivault_auth_client(params)
     name = params.get('name')
     rules = open(params.get('rules_file'), 'r').read()
+    changed = False
+    exists = False
+    current = str()
 
+    # does policy exit
     try:
         current = client.get_policy(name)
+        exists = True
     except:
         if module.check_mode:
             changed = True
 
-## need to redo this
-    if current == rules:
-        return {'changed': False}
+    # does current policy match desired
+    if exists:
+        if current != rules:
+            changed = True
 
-    client.sys.create_or_update_policy(name, rules)
-    return {'changed': True}
+    if exists and changed and not module.check_mode:
+        client.sys.create_or_update_policy(name, rules)
+
+    return {'changed': changed}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixing idempotency checks when using namespaces on several modules. 

modules show "changed" when using `-C` even if a namespace doesnt exist yet. previously they failed because the path to check current state didnt exist (no namespace 

regarding: https://github.com/TerryHowe/ansible-modules-hashivault/issues/167

more to come

