### PR TITLE
Enable OIDC auth config functional test

### DIFF
--- a/functional/run.sh
+++ b/functional/run.sh
@@ -23,7 +23,7 @@ ansible-playbook -v test_auth.yml
 ansible-playbook -v test_auth_method.yml
 ansible-playbook -v test_azure_auth_config.yml
 ansible-playbook -v test_azure_auth_role.yml
-# ansible-playbook -v test_oidc_auth_method_config.yml cannot run without enterprise
+ansible-playbook -v test_oidc_auth_method_config.yml
 ansible-playbook -v test_secret_list.yml
 # ansible-playbook -v test_namespace.yml cannot run without enterprise 
 # ansible-playbook -v test_db_config.yml cannot run without true db connectivity


### PR DESCRIPTION
OIDC auth configuration is available in open source Vault version 1.1 and **not** an enterprise-only feature.

https://www.hashicorp.com/blog/vault-1-1