### PR TITLE
Add OIDC auth role and functional test

### DIFF
--- a/ansible/modules/hashivault/hashivault_azure_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_role.py
@@ -102,7 +102,7 @@ EXAMPLES = '''
 ---
 - hosts: localhost
   tasks:
-      hashivault_azure_auth_role:
+    - hashivault_azure_auth_role:
         name: "test"
         policies: ["test"]
         bound_subscription_ids: ["6a1d5988-5917-4221-b224-904cd7e24a25"]
@@ -133,7 +133,6 @@ def main():
     argspec['num_uses'] = dict(required=False, type='int', default=0)
 
     supports_check_mode=True
-    # required_one_of=[['bound_service_principal_ids', 'bound_group_ids', 'bound_locations', 'bound_subscription_ids', 'bound_resource_groups', 'bound_scale_sets', 'role_file', 'state']]
 
     module = hashivault_init(argspec, supports_check_mode) #, required_one_of)
     result = hashivault_azure_auth_role(module)
@@ -199,7 +198,7 @@ def hashivault_azure_auth_role(module):
     # compare current_state to desired_state
     if exists and state == 'present' and not changed:
         current_state = client.auth.azure.read_role(name=name)
-        # Map a couplle elements
+        # Map a couple elements
         if 'ttl' not in current_state and 'token_ttl' in current_state:
             current_state['ttl'] = current_state['token_ttl']
         if 'max_ttl' not in current_state and 'token_max_ttl' in current_state:

--- a/ansible/modules/hashivault/hashivault_oidc_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_role.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+import json
+import requests
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_oidc_auth_role
+version_added: "4.1.1"
+short_description: Hashicorp Vault OIDC secret engine role
+description:
+    - Module to define an OIDC role that vault can generate dynamic credentials for vault
+options:
+    url:
+        description:
+            - url for vault
+        default: to environment variable VAULT_ADDR
+    ca_cert:
+        description:
+            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+        default: to environment variable VAULT_CACERT
+    ca_path:
+        description:
+            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
+             is specified, its value will take precedence"
+        default: to environment variable VAULT_CAPATH
+    client_cert:
+        description:
+            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+        default: to environment variable VAULT_CLIENT_CERT
+    client_key:
+        description:
+            - "path to an unencrypted PEM-encoded private key matching the client certificate"
+        default: to environment variable VAULT_CLIENT_KEY
+    verify:
+        description:
+            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
+             variable is not recommended except during testing"
+        default: to environment variable VAULT_SKIP_VERIFY
+    token:
+        description:
+            - token for vault
+        default: to environment variable VAULT_TOKEN
+    username:
+        description:
+            - username to login to vault.
+        default: to environment variable VAULT_USER
+    password:
+        description:
+            - password to login to vault.
+        default: to environment variable VAULT_PASSWORD
+    mount_point:
+        description:
+            - name of the secret engine mount name.
+        default: oidc
+    name:
+        description:
+            - name of the role in vault
+    bound_audiences:
+        description:
+            - List of `aud` claims to match against. Any match is sufficient.
+    user_claim:
+        description:
+            - The claim to use to uniquely identify the user; this will be used as the name for the Identity entity alias created due to a successful login. The claim value must be a string.
+        default: sub
+    bound_subject:
+        description:
+            - If set, requires that the sub claim matches this value.
+    bound_claims:
+        description:
+            - If set, a map of claims/values to match against. The expected value may be a single string or a list of strings.
+    groups_claim:
+        description:
+            The claim to use to uniquely identify the set of groups to which the user belongs; this will be used as the names for the Identity group aliases created due to a successful login. The claim value must be a list of strings.
+    claim_mappings:
+        description:
+            - If set, a map of claims (keys) to be copied to specified metadata fields (values).
+    oidc_scopes:
+        description:
+            - If set, a list of OIDC scopes to be used with an OIDC role. The standard scope "openid" is automatically included and need not be specified.
+    allowed_redirect_uris:
+        description:
+            - The list of allowed values for redirect_uri during OIDC logins.
+    token_ttl:
+        description:
+            - The incremental lifetime for generated tokens. This current value of this will be referenced at renewal time.
+    token_max_ttl:
+        description:
+            - The maximum lifetime for generated tokens. This current value of this will be referenced at renewal time.
+    token_policies:
+        description:
+            - List of policies to encode onto generated tokens. Depending on the auth method, this list may be supplemented by user/group/other values.
+    token_bound_cidrs:
+        description:
+            - List of CIDR blocks; if set, specifies blocks of IP addresses which can authenticate successfully, and ties the resulting token to these blocks as well.
+    token_explicit_max_ttl:
+        description:
+            - If set, will encode an explicit max TTL onto the token. This is a hard cap even if token_ttl and token_max_ttl would otherwise allow a renewal.
+    token_no_default_policy:
+        description:
+            - If set, the default policy will not be set on generated tokens; otherwise it will be added to the policies set in token_policies.
+    token_num_uses:
+        description:
+            - The maximum number of times a generated token may be used (within its lifetime); 0 means unlimited.
+    token_period:
+        description:
+            - If set, indicates that the token generated using this role should never expire. The token should be renewed within the duration specified by this value. At each renewal, the token's TTL will be set to the value of this parameter.
+    token_type:
+        description:
+            - The type of token that should be generated. Can be service, batch, or default to use the mount's tuned default (which unless changed will be service tokens). For token store roles, there are two additional possibilities: default-service and default-batch which specify the type to return unless the client requests a different type at generation time.
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_oidc_auth_role:
+        name: "gmail"
+        bound_audiences: ["123-456.apps.googleusercontent.com"]
+        allowed_redirect_uris: ["https://vault.com:8200/ui/vault/auth/oidc/oidc/callback"]
+        token_policies: ["test"]
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['state'] = dict(required=False, type='str', default='present', choices=['present', 'absent'])
+    argspec['name'] = dict(required=True, type='str')
+    argspec['mount_point'] = dict(required=False, type='str', default='oidc')
+    argspec['user_claim'] = dict(required=False, type='str', default='sub')
+    argspec['allowed_redirect_uris'] = dict(required=True, type='list')
+    argspec['bound_audiences'] = dict(required=False, type='list') 
+    argspec['bound_subject'] = dict(required=False, type='str', default='')
+    argspec['bound_claims'] = dict(required=False, type='dict')
+    argspec['groups_claim'] = dict(required=False, type='str', default='')
+    argspec['claim_mappings'] = dict(required=False, type='dict') 
+    argspec['oidc_scopes'] = dict(required=False, type='list', default=[])
+    argspec['token_ttl'] = dict(required=False, type='int', default=0)
+    argspec['token_max_ttl'] = dict(required=False, type='int', default=0)
+    argspec['token_policies'] = dict(required=False, type='list', default=[])
+    argspec['token_bound_cidrs'] = dict(required=False, type='list', default=[]) 
+    argspec['token_explicit_max_ttl'] = dict(required=False, type='int', default=0)
+    argspec['token_no_default_policy'] = dict(required=False, type='bool', default=False)
+    argspec['token_num_uses'] = dict(required=False, type='int', default=0)
+    argspec['token_period'] = dict(required=False, type='int', default=0)
+    argspec['token_type'] = dict(required=False, type='str', default='default')
+    argspec['clock_skew_leeway'] = dict(required=False, type='int', default=0)
+    argspec['expiration_leeway'] = dict(required=False, type='int', default=0)
+    argspec['not_before_leeway'] = dict(required=False, type='int', default=0)
+
+    supports_check_mode=False
+
+    module = hashivault_init(argspec, supports_check_mode) 
+    result = hashivault_oidc_auth_role(module)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_oidc_auth_role(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+    mount_point = params.get('mount_point')
+    name = params.get('name')
+    state = params.get('state')
+    desired_state = dict()
+    current_state = dict()
+    exists = False
+    changed = False
+
+    token = params['token']
+    headers = {'X-Vault-Token': token}
+    url = params['url']
+    verify = params['verify']
+
+    # do not want a trailing slash in name and mount_point
+    if name[-1] == '/':
+        name = name.strip('/')
+    if mount_point[-1]:
+        mount_point = mount_point.strip('/')
+
+    desired_state['allowed_redirect_uris'] = params.get('allowed_redirect_uris')
+    desired_state['bound_audiences'] = params.get('bound_audiences')
+    desired_state['bound_claims'] = params.get('bound_claims')
+    desired_state['bound_subject'] = params.get('bound_subject')
+    desired_state['claim_mappings'] = params.get('claim_mappings')
+    desired_state['groups_claim'] = params.get('groups_claim')
+    desired_state['oidc_scopes'] = params.get('oidc_scopes')
+    desired_state['token_bound_cidrs'] = params.get('token_bound_cidrs')
+    desired_state['token_explicit_max_ttl'] = params.get('token_explicit_max_ttl')
+    desired_state['token_ttl'] = params.get('token_ttl')
+    desired_state['token_max_ttl'] = params.get('token_max_ttl')
+    desired_state['token_no_default_policy'] = params.get('token_no_default_policy')
+    desired_state['token_policies'] = params.get('token_policies')
+    desired_state['token_type'] = params.get('token_type')
+    desired_state['user_claim'] = params.get('user_claim')
+    desired_state['token_period'] = params.get('token_period')
+    desired_state['token_num_uses'] = params.get('token_num_uses')
+    desired_state['clock_skew_leeway'] = params.get('clock_skew_leeway')
+    desired_state['expiration_leeway'] = params.get('expiration_leeway')
+    desired_state['not_before_leeway'] = params.get('not_before_leeway')
+
+
+    # check if engine is enabled
+    try:
+      if (mount_point + "/") not in client.sys.list_auth_methods()['data'].keys():
+        return {'failed': True, 'msg': 'auth method is not enabled', 'rc': 1}
+    except:
+        if module.check_mode:
+            changed = True
+        else:
+            return {'failed': True, 'msg': 'auth mount is not enabled or namespace is not created', 'rc': 1}
+
+    # check if role exists
+    try:
+        current_state = requests.get(url + '/v1/auth/' + mount_point + '/role/' + name, verify=verify, headers=headers)
+        if current_state.status_code == 404:
+            changed = True
+        elif current_state.status_code == 200:
+            exists = True
+    except:
+        changed = True 
+
+    if not exists and state == 'present':
+        changed = True
+    elif exists and state == 'absent':
+        changed = True
+
+    desired_state['role_type'] = "oidc"
+    desired_state['verbose_oidc_logging'] = False
+
+   #check if current role matches desired role values, if they dont match, set changed true
+    if exists and state == 'present':
+        current_state = current_state.json()['data']
+        for k, v in current_state.items():
+            if v != desired_state[k]:
+                changed = True
+
+    # make the changes!
+    if changed and state == 'present' and not module.check_mode:
+        config_status = requests.post(url + '/v1/auth/' + mount_point + '/role/' + name, verify=verify, headers=headers, json=desired_state)
+        try:
+            config_status.raise_for_status()
+        except:
+            return {'failed': True, 'msg': config_status.text, 'rc': 1}
+        return {'changed': changed}
+    elif changed and state == 'absent' and not module.check_mode:
+        config_status = requests.delete(url + '/v1/auth/' + mount_point + '/role/' + name, verify=verify, headers=headers, json=desired_state)
+        try:
+            config_status.raise_for_status()
+        except:
+            return {'failed': True, 'msg': config_status.text, 'rc': 1}
+    return {'changed': changed}
+
+
+if __name__ == '__main__':
+    main()

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -23,7 +23,8 @@ ansible-playbook -v test_auth.yml
 ansible-playbook -v test_auth_method.yml
 ansible-playbook -v test_azure_auth_config.yml
 ansible-playbook -v test_azure_auth_role.yml
-# ansible-playbook -v test_oidc_auth_method_config.yml cannot run without enterprise
+# ansible-playbook -v test_oidc_auth_method_config.yml cannot run without true discovery url
+# ansible-playbook -v test_oidc_auth_role.yml cannot run without true discovery url
 ansible-playbook -v test_secret_list.yml
 # ansible-playbook -v test_namespace.yml cannot run without enterprise 
 # ansible-playbook -v test_db_config.yml cannot run without true db connectivity

--- a/functional/test_oidc_auth_role.yml
+++ b/functional/test_oidc_auth_role.yml
@@ -1,0 +1,52 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  vars:
+    oidc_discovery_url: values
+    oidc_client_id: dont
+    oidc_client_secret: matter
+  tasks:
+    - hashivault_auth_method:
+        method_type: oidc
+        state: disabled
+      failed_when: false
+         
+    - name: enable oidc secret engine
+      hashivault_auth_method:
+        method_type: oidc
+         
+    - name: successfully configure mount
+      hashivault_oidc_auth_method_config:
+        oidc_discovery_url: "{{ oidc_discovery_url }}"
+        oidc_client_id: "{{ oidc_client_id }}"
+        oidc_client_secret: "{{ oidc_client_secret }}"
+
+    - name: create 1st role
+      hashivault_oidc_auth_role:
+        name: "test"
+        bound_audiences: ["123456"]
+        allowed_redirect_uris: ["https://123456.com/callback"]
+        token_policies: ["test"]
+      register: success_config
+    
+    - assert: { that: "{{ success_config.changed }} == True" }
+
+    - name: idempotently create role
+      hashivault_oidc_auth_role:
+        name: "test"
+        bound_audiences: ["123456"]
+        allowed_redirect_uris: ["https://123456.com/callback"]
+        token_policies: ["test"]
+      register: idem_config
+    
+    - assert: { that: "{{ idem_config.changed }} == False" }
+
+    - name: delete role
+      hashivault_oidc_auth_role:
+        name: "test"
+        state: absent
+        allowed_redirect_uris: ["https://123456.com/callback"]
+      register: del_config
+      
+    - assert: { that: "{{ del_config.changed }} == True" }


### PR DESCRIPTION
The HVAC library currently does not support OIDC auth role configuration so I have used the Python requests library to implement this feature.

 - [x] test for idempotency
 - [x] create `ansible-modules-hashivault/functional/test_oidc_auth_role.yml`