### PR TITLE
fix auth method

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -124,8 +124,6 @@ def hashivault_auth_method(module):
     except:
         if module.check_mode:
             changed = True
-        else:
-            return {'failed': True, 'msg': 'auth mount is not enabled or namespace does not exist', 'rc': 1}
 
     # if its off and we want it on
     if (state == 'enabled' or state == 'enable') and exists == False:


### PR DESCRIPTION
fixes: https://github.com/TerryHowe/ansible-modules-hashivault/issues/176

logic was used in auth methods / secret engines to check if a namespace pre-existed to account for check mode. part of the logic broke this method because it in fact **creates** the auth method which is what we were attempting to test