### PR TITLE
Added additional return value to auth_method and secrets_engine

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -109,6 +109,7 @@ def hashivault_auth_method(module):
     state = params.get('state')
     exists = False
     changed = False
+    created = False
 
     if mount_point == None:
         mount_point = method_type
@@ -144,13 +145,14 @@ def hashivault_auth_method(module):
     # brand new
     if changed and not exists and not module.check_mode and (state == 'enabled' or state == 'enable'):
         client.sys.enable_auth_method(method_type, description=description, path=mount_point, config=config)
+        created = True
     # delete existing
     if changed and not module.check_mode and (state == 'disabled' or state == 'disable'):
         client.sys.disable_auth_method(path=mount_point)
     # update existing
     if changed and exists and not module.check_mode and (state == 'enabled' or state == 'enable'):
         client.sys.tune_auth_method(description=description, path=mount_point, **config)
-    return {'changed': changed}
+    return {'changed': changed, 'created': created}
 
 if __name__ == '__main__':
     main()

--- a/ansible/modules/hashivault/hashivault_secret_engine.py
+++ b/ansible/modules/hashivault/hashivault_secret_engine.py
@@ -113,6 +113,7 @@ def hashivault_secret_engine(module):
     options = params.get('options')
     current_state = dict()
     exists = False
+    created = False
     changed = False
 
     if not backend:
@@ -156,6 +157,7 @@ def hashivault_secret_engine(module):
             client.sys.enable_secrets_engine(backend, description=description, path=name, config=config, options=options)
         else:
             client.sys.enable_secrets_engine(backend, description=description, path=name, config=config)
+        created = True
         
     # needs to be updated
     elif changed and exists and (state == 'present' or state == 'enabled') and not module.check_mode:
@@ -168,7 +170,7 @@ def hashivault_secret_engine(module):
     elif changed and (state == 'absent' or state == 'disabled') and not module.check_mode:
         client.sys.disable_secrets_engine(path=name)
 
-    return {'changed': changed}
+    return {'changed': changed, 'created': created}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi, i have added this value to differentiate between just created and updated secrets engine

``` YAML
---
- name: "Enable PKI Secrets Engine"
  run_once: true
  register: pki_engine
  hashivault_secret_engine:
    name: "{{ pki_path }}"
    backend: "pki"
    description: "My awesome PKI engine"
    config: "{{ pki_config }}"

- name: Configure PKI engine
  when: pki_engine is created
  block:
    - name: "Configure PKI Secrets Engine"
      run_once: true
      register: pki_engine_config
      hashivault_write:
        mount_point: "{{ pki_path }}"
        secret: "intermediate/generate/internal"
        data:
          common_name: "{{ pki_common_name }}"
          key_bits: "{{ key_bits | default(4096) }}"
          ttl: "{{ ttl | default('43800h') }}"
    - name: "........"
...
````
So in this example "Configure PKI engine" needs to be executed only when PKI secrets engine is created, but when it got tuned we don't need to reconfigure it, because it will recreate RSA key in Vault and trust will be broken and lost :(