### PR TITLE
fix for the playbooks that were not setting mount_point with kv v1

### DIFF
--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -133,7 +133,10 @@ def hashivault_list(params):
             if version == 2:
                 response = client.secrets.kv.v2.list_secrets(path=secret, mount_point=mount_point)
             else:
-                response = client.secrets.kv.v1.list_secrets(path=secret, mount_point=mount_point)
+                if mount_point == "secret" and version == 1:
+                    response = client.list(secret)
+                else:
+                    response = client.secrets.kv.v1.list_secrets(path=secret, mount_point=mount_point)
         except Exception as e:
           if response is None:
             response = {}


### PR DESCRIPTION
My playbook suddenly stopped working because I did not set mount_point for hashivault_list, since the 4.2.0 and changes by this PR : https://github.com/TerryHowe/ansible-modules-hashivault/pull/164

I fixed it and kindly propose to merge it in case some people are playbooks failing too. Even if I could just add mount_point in ansible playbook, it can save some time for people searching why the playbook suddenly fails.