### PR TITLE
Defaulting members to None when creating groups

### DIFF
--- a/ansible/modules/hashivault/hashivault_identity_group.py
+++ b/ansible/modules/hashivault/hashivault_identity_group.py
@@ -118,8 +118,8 @@ def main():
     argspec['mount_point'] = dict(required=False, type='str', default='identity')
     argspec['metadata'] = dict(required=False, type='dict', default={})
     argspec['policies'] = dict(required=False, type='list', default=[])
-    argspec['member_group_ids'] = dict(required=False, type='list', default=[])
-    argspec['member_entity_ids'] = dict(required=False, type='list', default=[])
+    argspec['member_group_ids'] = dict(required=False, type='list', default=None)
+    argspec['member_entity_ids'] = dict(required=False, type='list', default=None)
     argspec['state'] = dict(required=False, choices=['present', 'absent'], default='present')
     module = hashivault_init(argspec)
     result = hashivault_identity_group(module.params)
@@ -139,11 +139,11 @@ def hashivault_identity_group_update(group_details, client, group_id, group_name
     # for each respectively. The below is required to account for this
     
     # existing member_group_ids
-    if group_details['member_group_ids'] is not None:
+    if group_details['member_group_ids'] is not None and group_member_group_ids is not None:
         if set(group_details['member_group_ids']) != set(group_member_group_ids):
             changed = True
     # new member_group_ids and none existing
-    elif len(group_member_group_ids) > 0:
+    elif group_member_group_ids is not None and len(group_member_group_ids) > 0:
         changed = True
 
     # existing policies
@@ -155,11 +155,11 @@ def hashivault_identity_group_update(group_details, client, group_id, group_name
         changed = True
 
     # existing member_entity_ids
-    if group_details['member_entity_ids'] is not None:
+    if group_details['member_entity_ids'] is not None and group_member_entity_ids is not None:
         if set(group_details['member_entity_ids']) != set(group_member_entity_ids):
             changed = True
     # new member_entity_ids and none existing
-    elif len(group_member_entity_ids) > 0:
+    elif group_member_entity_ids is not None and len(group_member_entity_ids) > 0:
         changed = True
     
     # existing metadata


### PR DESCRIPTION
When creating groups with the hashivault_identity_group module, there is a bug when creating external groups: the Vault API does not expect members when creating external groups, and defaulting to an empty array passes it as an argument. This leads to an error from the Vault API: "Exception: member entities can't be set manually for external groups".