### PR TITLE
Feature/idempotant auth

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -120,7 +120,6 @@ def hashivault_auth_method(module):
         path = (mount_point or method_type) + u"/"
 
         # Is auth method enabled already?
-
         if path in auth_methods['data'].keys():
             exists = True
     except:

--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -120,6 +120,7 @@ def hashivault_auth_method(module):
         path = (mount_point or method_type) + u"/"
 
         # Is auth method enabled already?
+
         if path in auth_methods['data'].keys():
             exists = True
     except:
@@ -144,7 +145,7 @@ def hashivault_auth_method(module):
             config['force_no_cache'] = False
         if 'token_type' not in config:
             config['token_type'] = 'default-service'
-        if current_state['data'] != config:
+        if not current_state['data'].items() >= config.items():
             changed = True
 
     # brand new


### PR DESCRIPTION
The current method compares the dictionary from the Vault API and the configuration that is desired.

This is very difficult to make idempotent because the Vault API applies some defaults that you also need to set in your module parameters. It only makes sense to check that your desired parameters are set, and if not they can up be updated.