### PR TITLE
Centralizing common doc 

### DIFF
--- a/ansible/modules/hashivault/_hashivault_approle_role_create.py
+++ b/ansible/modules/hashivault/_hashivault_approle_role_create.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault approle create role module
 description:
     - Module to create an approle role from Hashicorp Vault. Use hashivault_approle_role instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
@@ -92,6 +50,7 @@ options:
     enable_local_secret_ids:
         description:
             - If set, the secret IDs generated using this role will be cluster local.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_approle_role_secret_create.py
+++ b/ansible/modules/hashivault/_hashivault_approle_role_secret_create.py
@@ -15,48 +15,6 @@ description:
     - Module to get an approle role secret id from Hashicorp Vault in Pull mode
       or create custom approle role secret id in Push mode. Use hashivault_approle_role_secret instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - secret name.
@@ -72,6 +30,7 @@ options:
     wrap_ttl:
         description:
             - Wrap TTL.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_approle_role_secret_delete.py
+++ b/ansible/modules/hashivault/_hashivault_approle_role_secret_delete.py
@@ -14,54 +14,13 @@ short_description: Hashicorp Vault approle role secret id delete module
 description:
     - Module to delete a approle role secret id from Hashicorp Vault. Use hashivault_approle_role_secret instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
     secret:
         description:
             - secret id.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_audit_enable.py
+++ b/ansible/modules/hashivault/_hashivault_audit_enable.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault audit enable module
 description:
     - Module to enable audit backends in Hashicorp Vault. Use hashivault_audit instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - name of auditor
@@ -64,6 +22,7 @@ options:
     options:
         description:
             - options for auditor
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_auth_enable.py
+++ b/ansible/modules/hashivault/_hashivault_auth_enable.py
@@ -15,48 +15,6 @@ short_description: Hashicorp Vault auth enable module
 description:
     - Use hashivault_auth_method instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - name of authenticator
@@ -66,6 +24,7 @@ options:
     mount_point:
         description:
             - location where this auth backend will be mounted
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_mount_tune.py
+++ b/ansible/modules/hashivault/_hashivault_mount_tune.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault tune backend
 description:
     - Module to enable tuning of backends in HashiCorp Vault. use hashivault_secret_engine instead
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - location where this auth backend will be mounted
@@ -64,6 +22,7 @@ options:
     max_lease_ttl:
         description:
             - Configures the maximum lease duration for tokens and secrets. This is an integer value in seconds.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_policy_set_from_file.py
+++ b/ansible/modules/hashivault/_hashivault_policy_set_from_file.py
@@ -13,54 +13,13 @@ short_description: Hashicorp Vault policy set from a file module
 description:
     - Module to set a policy from a file in Hashicorp Vault. Use hashivault_policy_set instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - policy name.
     rules_file:
         description:
             - policy rules file.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_secret_disable.py
+++ b/ansible/modules/hashivault/_hashivault_secret_disable.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault secret disable module
 description:
     - Module to disable secret backends in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - name of secret backend
@@ -67,6 +25,7 @@ options:
     config:
         description:
             - config of secret backend
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_secret_enable.py
+++ b/ansible/modules/hashivault/_hashivault_secret_enable.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault secret enable module
 description:
     - Module to enable secret backends in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - name of secret backend
@@ -70,6 +28,7 @@ options:
     options:
         description:
             - options of secret backend
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_userpass_create.py
+++ b/ansible/modules/hashivault/_hashivault_userpass_create.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault userpass create module
 description:
     - Module to create userpass users in Hashicorp Vault. Use hashicorp_userpass instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - user name to create.
@@ -69,6 +27,7 @@ options:
         description:
             - default The "path" (app-id) the auth backend is mounted on.
         default: userpass
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/_hashivault_userpass_delete.py
+++ b/ansible/modules/hashivault/_hashivault_userpass_delete.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault userpass delete module
 description:
     - Module to delete userpass users in Hashicorp Vault. Use hashicorp_userpass instead.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - user name.
@@ -62,6 +20,7 @@ options:
         description:
             - default The "path" (app-id) the auth backend is mounted on.
         default: userpass
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_approle_role_get.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_get.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault approle role get module
 description:
     - Module to get a approle role from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
@@ -62,6 +20,7 @@ options:
         description:
             - mount point for role
         default: approle
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_approle_role_id.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_id.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault approle get role id module
 description:
     - Module to get a approle role id from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
@@ -62,6 +20,7 @@ options:
         description:
             - mount point for role
         default: approle
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_approle_role_list.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_list.py
@@ -13,52 +13,11 @@ short_description: Hashicorp Vault approle list roles module
 description:
     - Module to list approle roles from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - mount point for role
         default: approle
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_approle_role_secret_accessor_get.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_secret_accessor_get.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault approle role secret accessor get module
 description:
     - Module to get a approle role secret accessor from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
@@ -65,6 +23,7 @@ options:
     accessor:
         description:
             - accessor id.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_approle_role_secret_get.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_secret_get.py
@@ -14,48 +14,6 @@ short_description: Hashicorp Vault approle role secret id get module
 description:
     - Module to get a approle role secret id from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
@@ -66,6 +24,7 @@ options:
     secret:
         description:
             - secret id.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_approle_role_secret_list.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_secret_list.py
@@ -14,48 +14,6 @@ short_description: Hashicorp Vault approle role secret id get module
 description:
     - Module to get a approle role secret id from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
@@ -63,6 +21,7 @@ options:
         description:
             - mount point for role
         default: approle
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_audit_list.py
+++ b/ansible/modules/hashivault/hashivault_audit_list.py
@@ -12,49 +12,7 @@ version_added: "2.2.0"
 short_description: Hashicorp Vault audit list module
 description:
     - Module to list audit backends in Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_auth_ldap.py
+++ b/ansible/modules/hashivault/hashivault_auth_ldap.py
@@ -15,48 +15,6 @@ short_description: Hashicorp Vault ldap configuration module
 description:
     - Module to configure the LDAP authentication method in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - location where this auth_method is mounted. also known as "path"
@@ -133,7 +91,7 @@ options:
         description:
             - LDAP search base to use for group membership search
         default: ''
-
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_auth_list.py
+++ b/ansible/modules/hashivault/hashivault_auth_list.py
@@ -12,49 +12,7 @@ version_added: "2.2.0"
 short_description: Hashicorp Vault auth list module
 description:
     - Module to list authentication backends in Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault auth module
 description:
     - Module to enable or disable authentication ethods in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     method_type:
         description:
             - name of auth method. [required]
@@ -73,6 +31,7 @@ options:
             - configuration set on auth method. expects a dict
         default: "{'default_lease_ttl': 2764800, 'max_lease_ttl': 2764800, 'force_no_cache':False,
                   'token_type': 'default-service'}"
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_aws_ec2_role_create.py
+++ b/ansible/modules/hashivault/hashivault_aws_ec2_role_create.py
@@ -16,48 +16,6 @@ short_description: Hashicorp Vault aws ec2 create role module
 description:
     - Module to create a aws ec2 backed vault role
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - role name.
@@ -112,6 +70,7 @@ options:
     mount_point:
         description:
             - location where this auth_method will be mounted. also known as "path"
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_azure_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_config.py
@@ -14,48 +14,6 @@ short_description: Hashicorp Vault azure auth config
 description:
     - Module to configure an azure auth mount
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - name of the secret engine mount name.
@@ -80,6 +38,7 @@ options:
         description:
             - the azure AD resource the auth method accesses. default is likely OK
         default: https://management.azure.com
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_azure_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_role.py
@@ -15,48 +15,6 @@ short_description: Hashicorp Vault azure secret engine role
 description:
     - Module to define a Azure role that vault can generate dynamic credentials for vault
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - name of the secret engine mount name.
@@ -100,6 +58,7 @@ options:
         description:
             - File with a json object containing play parameters. pass all params but name, state, mount_point which
               stay in the ansible play
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -14,48 +14,6 @@ short_description: Hashicorp Vault azure secret engine config
 description:
     - Module to configure an azure secret engine via variables or json file
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - name of the secret engine mount name.
@@ -79,6 +37,7 @@ options:
         description:
             - azure environment. you probably do not want to change this
         default: AzurePublicCloud
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
@@ -15,48 +15,6 @@ short_description: Hashicorp Vault azure secret engine role
 description:
     - Module to define a Azure role that vault can generate dynamic credentials for vault
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - name of the secret engine mount name.
@@ -70,6 +28,7 @@ options:
     azure_role_file:
         description:
             - file with a single dict, azure_role
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_cluster_status.py
+++ b/ansible/modules/hashivault/hashivault_cluster_status.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault cluster status module
 description:
     - Module to get cluster status of Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     standby_ok:
         description:
             - Specifies if being a standby should still return the active status code instead of the standby status code
@@ -64,6 +22,7 @@ options:
         - Method to use to get cluster status, supported methods are HEAD (produces 000 (empty body)) and GET (produces
           000 application/json)
       default: HEAD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
@@ -14,48 +14,6 @@ short_description: Hashicorp Vault database secrets engine config
 description:
     - Module to configure a database secrets engine
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - name of the secret engine mount name.
@@ -89,6 +47,7 @@ options:
             - Specifies the database statements to be executed to rotate the root user's credentials. See the plugin's
               API page for more information on support and formatting for this parameter.
         default: []
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_db_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_role.py
@@ -15,48 +15,6 @@ short_description: Hashicorp Vault database secret engine role
 description:
     - Module to define a database role that vault can generate dynamic credentials for vault
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - name of the secret engine mount name.
@@ -100,6 +58,7 @@ options:
             - Specifies the database statements to be executed to renew a user. Not every plugin type will support this
               functionality. See the plugin's API page for more information on support and formatting for this
               parameter.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_delete.py
+++ b/ansible/modules/hashivault/hashivault_delete.py
@@ -17,48 +17,6 @@ short_description: Hashicorp Vault delete module
 description:
     - Module to delete from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     version:
         description:
             - version of the kv engine (int)
@@ -70,6 +28,7 @@ options:
     secret:
         description:
             - secret to delete.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_generate_root.py
+++ b/ansible/modules/hashivault/hashivault_generate_root.py
@@ -13,54 +13,13 @@ short_description: Hashicorp Vault generate_root module
 description:
     - Module to (update) generate_root Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     key:
         description:
             - vault key shard.
     nonce:
         description:
             - generate_root nonce.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_generate_root_cancel.py
+++ b/ansible/modules/hashivault/hashivault_generate_root_cancel.py
@@ -12,49 +12,7 @@ version_added: "3.14.0"
 short_description: Hashicorp Vault generate_root cancel module
 description:
     - Module to cancel generation of root token of Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_generate_root_init.py
+++ b/ansible/modules/hashivault/hashivault_generate_root_init.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault generate root token init module
 description:
     - Module to start root token generation of Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     secret_shares:
         description:
             - specifies the number of shares to split the master key into.
@@ -67,6 +25,7 @@ options:
         description:
             - specifies PGP public keys used to encrypt the output root token.
         default: ''
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_generate_root_status.py
+++ b/ansible/modules/hashivault/hashivault_generate_root_status.py
@@ -12,49 +12,7 @@ version_added: "3.14.0"
 short_description: Hashicorp Vault generate_root status module
 description:
     - Module to get generate_root status of Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_identity_entity.py
+++ b/ansible/modules/hashivault/hashivault_identity_entity.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault entity create module
 description:
     - Module to manage identity entity in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - entity name to create or update.
@@ -73,6 +31,7 @@ options:
     state:
         description:
             - whether create/update or delete the entity
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_identity_entity_alias.py
+++ b/ansible/modules/hashivault/hashivault_identity_entity_alias.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault entity alias manage module
 description:
     - Module to manage identity entity aliases in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - Name of the alias. Name should be the identifier of the client in the authentication source.
@@ -73,6 +31,7 @@ options:
     state:
         description:
             - whether crete/update or delete the entity
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_identity_group.py
+++ b/ansible/modules/hashivault/hashivault_identity_group.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault identity group configuration module
 description:
     - Module to configure identity groups in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     mount_point:
         description:
             - location where this method/backend is mounted. also known as "path"
@@ -90,6 +48,7 @@ options:
     state:
         description:
             - whether create/update or delete the entity
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_init.py
+++ b/ansible/modules/hashivault/hashivault_init.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault init enable module
 description:
     - Module to init Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     secret_shares:
         description:
             - specifies the number of shares to split the master key into.
@@ -87,6 +45,7 @@ options:
         description:
             - specifies an array of PGP public keys used to encrypt the output recovery keys.
         default: None
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_leader.py
+++ b/ansible/modules/hashivault/hashivault_leader.py
@@ -12,49 +12,7 @@ version_added: "3.16.4"
 short_description: Hashicorp Vault leader module
 description:
     - Module to get leader information of Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -18,48 +18,6 @@ description:
       can provide an alternate location as I(secret).  This includes both
       immediate subkeys and subkey paths, like the C(vault list) command.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     secret:
         description:
             - 'secret path to list.  If this does not begin with a C(/)
@@ -77,6 +35,7 @@ options:
         description:
             - secret mount point
         default: secret
+extends_documentation_fragment: hashivault
 '''
 RETURN = '''
 ---

--- a/ansible/modules/hashivault/hashivault_policy_delete.py
+++ b/ansible/modules/hashivault/hashivault_policy_delete.py
@@ -13,51 +13,10 @@ short_description: Hashicorp Vault policy delete module
 description:
     - Module to delete a policy from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - policy name.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_policy_get.py
+++ b/ansible/modules/hashivault/hashivault_policy_get.py
@@ -13,51 +13,10 @@ short_description: Hashicorp Vault policy get module
 description:
     - Module to get a policy from Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - policy name.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_policy_list.py
+++ b/ansible/modules/hashivault/hashivault_policy_list.py
@@ -12,49 +12,7 @@ version_added: "2.1.0"
 short_description: Hashicorp Vault policy list module
 description:
     - Module to list policies in Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_policy_set.py
+++ b/ansible/modules/hashivault/hashivault_policy_set.py
@@ -13,54 +13,13 @@ short_description: Hashicorp Vault policy set module
 description:
     - Module to set a policy in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - policy name.
     rules:
         description:
             - policy rules.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault read module
 description:
     - Module to read to Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     version:
         description:
             - version of the kv engine (int)
@@ -72,6 +30,7 @@ options:
     register:
         description:
             - variable to register result.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_read_to_file.py
+++ b/ansible/modules/hashivault/hashivault_read_to_file.py
@@ -10,28 +10,6 @@ description:
     - "Reads and deocdes a base64 encoded file from Hashicorp Vault and saves it to disk. Implementation in\
      `/plugins/action/hashivault_read_to_file.py`."
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    verify:
-        description:
-            - verify TLS certificate
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-    password:
-        description:
-            - password to login to vault.
     secret:
         description:
             - vault secret to read.
@@ -50,6 +28,7 @@ options:
             - file permissions of file to write on remote host.
             - in octal, don't forget leading zero!
         default: 0664
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_rekey.py
+++ b/ansible/modules/hashivault/hashivault_rekey.py
@@ -14,54 +14,13 @@ description:
     - Module to (update) rekey Hashicorp Vault. Requires that a rekey
       be started with hashivault_rekey_init.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - authentication type to use: token, userpass, github, ldap
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     key:
         description:
             - vault key shard (aka unseal key).
     nonce:
         description:
             - rekey nonce.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_rekey_cancel.py
+++ b/ansible/modules/hashivault/hashivault_rekey_cancel.py
@@ -12,49 +12,7 @@ version_added: "3.3.0"
 short_description: Hashicorp Vault rekey cancel module
 description:
     - Module to cancel rekey Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_rekey_init.py
+++ b/ansible/modules/hashivault/hashivault_rekey_init.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault rekey init module
 description:
     - Module to start rekey Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     secret_shares:
         description:
             - specifies the number of shares to split the master key into.
@@ -67,6 +25,7 @@ options:
         description:
             - specifies an array of PGP public keys used to encrypt the output unseal keys.
         default: []
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_rekey_status.py
+++ b/ansible/modules/hashivault/hashivault_rekey_status.py
@@ -12,49 +12,7 @@ version_added: "3.3.0"
 short_description: Hashicorp Vault rekey status module
 description:
     - Module to get rekey status of Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_seal.py
+++ b/ansible/modules/hashivault/hashivault_seal.py
@@ -12,49 +12,7 @@ version_added: "1.2.0"
 short_description: Hashicorp Vault seal module
 description:
     - Module to seal Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_secret_engine.py
+++ b/ansible/modules/hashivault/hashivault_secret_engine.py
@@ -14,48 +14,6 @@ short_description: Hashicorp Vault secret enable/disable module
 description:
     - Module to enable secret backends in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - name of secret backend
@@ -75,6 +33,7 @@ options:
     options:
         description:
             - Specifies mount type specific options that are passed to the backend. NOT included unless backend == kv
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_secret_list.py
+++ b/ansible/modules/hashivault/hashivault_secret_list.py
@@ -12,49 +12,7 @@ version_added: "2.2.0"
 short_description: Hashicorp Vault secret list module
 description:
     - Module to list secret backends in Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_status.py
+++ b/ansible/modules/hashivault/hashivault_status.py
@@ -12,49 +12,7 @@ version_added: "1.2.0"
 short_description: Hashicorp Vault status module
 description:
     - Module to get status of Hashicorp Vault.
-options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_token_create.py
+++ b/ansible/modules/hashivault/hashivault_token_create.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault token create module
 description:
     - Module to create tokens in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     role:
         description:
             - If set, the token will be created against the named role
@@ -103,6 +61,7 @@ options:
     explicit_max_ttl:
         description:
             - An explicit maximum lifetime for the token
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_token_lookup.py
+++ b/ansible/modules/hashivault/hashivault_token_lookup.py
@@ -14,48 +14,6 @@ short_description: Hashicorp Vault token lookup module
 description:
     - Module to look up / check for existence of tokens in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     lookup_token:
         description:
             - token to lookup if different from auth token
@@ -66,6 +24,7 @@ options:
     wrap_ttl:
         description:
             - Indicates that the response should be wrapped in a cubbyhole token with the requested TTL.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_token_renew.py
+++ b/ansible/modules/hashivault/hashivault_token_renew.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault token renew module
 description:
     - Module to renew tokens in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     renew_token:
         description:
             - token to renew if different from auth token
@@ -66,6 +24,7 @@ options:
     wrap_ttl:
         description:
             - Indicates that the response should be wrapped in a cubbyhole token with the requested TTL.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_token_revoke.py
+++ b/ansible/modules/hashivault/hashivault_token_revoke.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault token revoke module
 description:
     - Module to revoke tokens in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     revoke_token:
         description:
             - token to revoke if different from auth token
@@ -65,6 +23,7 @@ options:
     orphan:
         description:
             - If set, Vault will revoke only the token, leaving the children as orphans.
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_unseal.py
+++ b/ansible/modules/hashivault/hashivault_unseal.py
@@ -13,51 +13,10 @@ short_description: Hashicorp Vault unseal module
 description:
     - Module to unseal Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     keys:
         description:
             - vault key shard(s).
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_userpass.py
+++ b/ansible/modules/hashivault/hashivault_userpass.py
@@ -13,48 +13,6 @@ short_description: Hashicorp Vault userpass user management module
 description:
     - Module to manage userpass users in Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     name:
         description:
             - user name to create.
@@ -80,6 +38,7 @@ options:
         description:
             - default The "path" (app-id) the auth backend is mounted on.
         default: userpass
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -17,48 +17,6 @@ short_description: Hashicorp Vault write module
 description:
     - Module to write to Hashicorp Vault.
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    ca_cert:
-        description:
-            - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
-        default: to environment variable VAULT_CACERT
-    ca_path:
-        description:
-            - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert
-             is specified, its value will take precedence"
-        default: to environment variable VAULT_CAPATH
-    client_cert:
-        description:
-            - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
-        default: to environment variable VAULT_CLIENT_CERT
-    client_key:
-        description:
-            - "path to an unencrypted PEM-encoded private key matching the client certificate"
-        default: to environment variable VAULT_CLIENT_KEY
-    verify:
-        description:
-            - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this
-             variable is not recommended except during testing"
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-        default: to environment variable VAULT_USER
-    password:
-        description:
-            - password to login to vault.
-        default: to environment variable VAULT_PASSWORD
     version:
         description:
             - version of the kv engine (int)
@@ -80,6 +38,7 @@ options:
         description:
             - Update rather than overwrite.
         default: False
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/modules/hashivault/hashivault_write_from_file.py
+++ b/ansible/modules/hashivault/hashivault_write_from_file.py
@@ -10,28 +10,6 @@ description:
     - "Writes a file encoded in base64 to Hashicorp Vault. Implementation in
      `/plugins/action/hashivault_write_from_file.py`."
 options:
-    url:
-        description:
-            - url for vault
-        default: to environment variable VAULT_ADDR
-    verify:
-        description:
-            - verify TLS certificate
-        default: to environment variable VAULT_SKIP_VERIFY
-    authtype:
-        description:
-            - "authentication type to use: token, userpass, github, ldap, approle"
-        default: token
-    token:
-        description:
-            - token for vault
-        default: to environment variable VAULT_TOKEN
-    username:
-        description:
-            - username to login to vault.
-    password:
-        description:
-            - password to login to vault.
     secret:
         description:
             - vault secret to write.
@@ -45,6 +23,7 @@ options:
         description:
             - Update secret rather than overwrite.
         default: True
+extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
 ---

--- a/ansible/plugins/doc_fragments/hashivault.py
+++ b/ansible/plugins/doc_fragments/hashivault.py
@@ -1,7 +1,6 @@
 class ModuleDocFragment(object):
     # Standard documentation
     DOCUMENTATION = r'''
-    author: "Terry Howe (@TerryHowe)"
     requirements:
         - hvac>=0.10.1
         - ansible>=2.0.0

--- a/ansible/plugins/doc_fragments/hashivault.py
+++ b/ansible/plugins/doc_fragments/hashivault.py
@@ -1,0 +1,51 @@
+class ModuleDocFragment(object):
+    # Standard documentation
+    DOCUMENTATION = r'''
+    author: "Terry Howe (@TerryHowe)"
+    requirements:
+        - hvac>=0.10.1
+        - ansible>=2.0.0
+        - requests
+    options:
+        url:
+            description:
+                - url for vault
+            default: to environment variable C(VAULT_ADDR)
+        ca_cert:
+            description:
+                - "path to a PEM-encoded CA cert file to use to verify the Vault server TLS certificate"
+            default: to environment variable C(VAULT_CACERT)
+        ca_path:
+            description:
+                - "path to a directory of PEM-encoded CA cert files to verify the Vault server TLS certificate : if ca_cert is specified, its value will take precedence"
+            default: to environment variable C(VAULT_CAPATH)
+        client_cert:
+            description:
+                - "path to a PEM-encoded client certificate for TLS authentication to the Vault server"
+            default: to environment variable C(VAULT_CLIENT_CERT)
+        client_key:
+            description:
+                - "path to an unencrypted PEM-encoded private key matching the client certificate"
+            default: to environment variable C(VAULT_CLIENT_KEY)
+        verify:
+            description:
+                - "if set, do not verify presented TLS certificate before communicating with Vault server : setting this variable is not recommended except during testing"
+            default: to environment variable C(VAULT_SKIP_VERIFY)
+        authtype:
+            description:
+                - authentication type
+            default: token
+            choices: ["token", "userpass", "github", "ldap", "approle"]
+        token:
+            description:
+                - token for vault
+            default: to environment variable C(VAULT_TOKEN)
+        username:
+            description:
+                - username to login to vault.
+            default: to environment variable C(VAULT_USER)
+        password:
+            description:
+                - password to login to vault.
+            default: to environment variable C(VAULT_PASSWORD)
+'''

--- a/link.sh
+++ b/link.sh
@@ -1,14 +1,16 @@
-DEST=$(echo ${VIRTUAL_ENV}/lib/python*/site-packages/ansible/)
+#! /bin/sh
+DEST=$(echo "${VIRTUAL_ENV}"/lib/python*/site-packages/ansible/)
 
-rm -rf $DEST/modules/hashivault
-rm -f $DEST/module_utils/hashivault.py
-rm -f $DEST/plugins/lookup/hashivault.py
-rm -f $DEST/plugins/action/hashivault_read_to_file.py
-rm -f $DEST/plugins/action/hashivault_write_from_file.py
+rm -rf "$DEST"/modules/hashivault
+rm -f "$DEST"/module_utils/hashivault.py
+rm -f "$DEST"/plugins/lookup/hashivault.py
+rm -f "$DEST"/plugins/doc_fragments/hashivault.py
+rm -f "$DEST"/plugins/action/hashivault_read_to_file.py
+rm -f "$DEST"/plugins/action/hashivault_write_from_file.py
 
-ln -s $PWD/ansible/modules/hashivault $DEST/modules/hashivault
-ln $PWD/ansible/module_utils/hashivault.py $DEST/module_utils/hashivault.py
-ln $PWD/ansible/plugins/lookup/hashivault.py $DEST/plugins/lookup/hashivault.py
-ln $PWD/ansible/plugins/action/hashivault_read_to_file.py $DEST/plugins/action/hashivault_read_to_file.py
-ln $PWD/ansible/plugins/action/hashivault_write_from_file.py $DEST/plugins/action/hashivault_write_from_file.py
-
+ln -s "$PWD"/ansible/modules/hashivault "$DEST"/modules/hashivault
+ln "$PWD"/ansible/module_utils/hashivault.py "$DEST"/module_utils/hashivault.py
+ln "$PWD"/ansible/plugins/lookup/hashivault.py "$DEST"/plugins/lookup/hashivault.py
+ln "$PWD"/ansible/plugins/doc_fragments/hashivault.py "$DEST"/plugins/doc_fragments/hashivault.py
+ln "$PWD"/ansible/plugins/action/hashivault_read_to_file.py "$DEST"/plugins/action/hashivault_read_to_file.py
+ln "$PWD"/ansible/plugins/action/hashivault_write_from_file.py "$DEST"/plugins/action/hashivault_write_from_file.py

--- a/makedocs.sh
+++ b/makedocs.sh
@@ -2,13 +2,15 @@
 export PLUGINS=''
 rm -rf ansible-repo
 mkdir ansible-repo && cd ansible-repo
-git clone https://github.com/ansible/ansible.git && cd ansible &&  git checkout v2.7.6 && cd ..
+git clone --branch 'v2.9.6' https://github.com/ansible/ansible.git
 pip install sphinx sphinx_rtd_theme
 pip install -r ansible/requirements.txt
 rm -rf ansible/lib/ansible/modules/ && mkdir -p ansible/lib/ansible/modules/hashivault
 cp -r ../ansible/modules/hashivault/hashivault*.py ansible/lib/ansible/modules/hashivault/
+rm -f ansible/lib/ansible/plugins/doc_fragments/hashivault.py
+cp {..,ansible/lib}/ansible/plugins/doc_fragments/hashivault.py
 ls ansible/lib/ansible/modules/hashivault
-export MODULES=$(ls -m ansible/lib/ansible/modules/hashivault/ | grep -v '^_' | tr -d '[:space:]'  | sed 's/.py//g')
+export MODULES=$(ls -m ansible/lib/ansible/modules/hashivault/ | grep -v '^_' | tr -d '[:space:]' | sed 's/.py//g')
 cd ansible/docs/docsite/
 make webdocs || true
 touch _build/html/.nojekyll


### PR DESCRIPTION
It's just an improvement proposal.

Using [documentation fragments](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#documentation-fragments) will improve the serviceability of documentation. As common items from `hashivault_argspec` are applied to all modules I think keeping their doc in one place would be beneficial.