### PR TITLE
Centralised common logic

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -251,3 +251,45 @@ class AppRoleClient(object):
         resp = client.auth_approle(role_id, secret_id=secret_id, mount_point=login_mount_point)
         client.token = str(resp['auth']['client_token'])
         return attr
+
+
+def check_secrets_engines(module, client):
+    """Checks if secrets engine is mounted
+
+    :param module: Ansible module. Must contain mount_point in parameters.
+    :param mounted: HVAC client
+    :return: change status, error
+    :rtype: (bool, dict)
+    """
+    changed = False
+    err = None
+    try:
+        if (module.params.get('mount_point') + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
+            err = {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
+    except:
+        if module.check_mode:
+            changed = True
+        else:
+            err = {'failed': True, 'msg': 'secret engine is not enabled or namespace does not exist', 'rc': 1}
+    return changed, err
+
+def check_auth_methods(module, client):
+    """Checks if auth engine is mounted
+
+    :param module: Ansible module. Must contain mount_point in parameters.
+    :param mounted: HVAC client
+    :return: change status, error
+    :rtype: (bool, dict)
+    """
+    changed = False
+    err = None
+    try:
+        if (module.params.get('mount_point') + "/") not in client.sys.list_auth_methods()['data'].keys():
+            err = {'failed': True, 'msg': 'auth method is not enabled', 'rc': 1}
+    except:
+        if module.check_mode:
+            changed = True
+        else:
+            err = {'failed': True, 'msg': 'auth mount is not enabled or namespace does not exist', 'rc': 1}
+
+    return changed, err

--- a/ansible/modules/hashivault/hashivault_azure_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_role.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ansible.module_utils.hashivault import check_auth_methods
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
@@ -139,15 +140,10 @@ def hashivault_azure_auth_role(module):
         desired_state['bound_scale_sets'] = params.get('bound_scale_sets')
         desired_state['num_uses'] = params.get('num_uses')
 
-    # check if engine is enabled
-    try:
-        if (mount_point + "/") not in client.sys.list_auth_methods()['data'].keys():
-            return {'failed': True, 'msg': 'auth method is not enabled', 'rc': 1}
-    except:
-        if module.check_mode:
-            changed = True
-        else:
-            return {'failed': True, 'msg': 'auth mount is not enabled or namespace does not exist', 'rc': 1}
+    # check if engine is enable
+    changed, err = check_auth_methods(module, client)
+    if err:
+        return err
 
     # check if role exists
     try:

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ansible.module_utils.hashivault import check_secrets_engines
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
@@ -102,14 +103,9 @@ def hashivault_azure_secret_engine_config(module):
         desired_state['environment'] = params.get('environment')
 
     # check if engine is enabled
-    try:
-        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
-            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
-    except:
-        if module.check_mode:
-            changed = True
-        else:
-            return {'failed': True, 'msg': 'secret engine is not enabled or namespace does not exist', 'rc': 1}
+    changed, err = check_secrets_engines(module, client)
+    if err:
+        return err
 
     # check if current config matches desired config values, if they match, set changed to false to prevent action
     try:

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ansible.module_utils.hashivault import check_secrets_engines
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
@@ -83,14 +84,9 @@ def hashivault_azure_secret_engine_role(module):
         azure_role = json.loads(open(params.get('azure_role_file'), 'r').read())['azure_role']
 
     # check if engine is enabled
-    try:
-        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
-            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
-    except:
-        if module.check_mode:
-            changed = True
-        else:
-            return {'failed': True, 'msg': 'secret engine is not enabled or namespace does not exist', 'rc': 1}
+    changed, err = check_secrets_engines(module, client)
+    if err:
+        return err
 
     # check if role exists or any at all
     try:

--- a/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ansible.module_utils.hashivault import check_secrets_engines
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
@@ -126,14 +127,9 @@ def hashivault_db_secret_engine_config(module):
         desired_state['root_credentials_rotate_statements'] = []
 
     # check if engine is enabled
-    try:
-        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
-            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
-    except:
-        if module.check_mode:
-            changed = True
-        else:
-            return {'failed': True, 'msg': 'secret engine is not enabled or namespace does not exist', 'rc': 1}
+    changed, err = check_secrets_engines(module, client)
+    if err:
+        return err
 
     # check if any config exists
     try:

--- a/ansible/modules/hashivault/hashivault_db_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_role.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ansible.module_utils.hashivault import check_secrets_engines
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
@@ -132,14 +133,9 @@ def hashivault_db_secret_engine_role(module):
         desired_state['db_name'] = params.get('db_name')
 
     # check if engine is enabled
-    try:
-        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
-            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
-    except:
-        if module.check_mode:
-            changed = True
-        else:
-            return {'failed': True, 'msg': 'secret engine is not enabled or namespace does not exist', 'rc': 1}
+    changed, err = check_secrets_engines(module, client)
+    if err:
+        return err
 
     # check if role exists
     try:

--- a/ansible/modules/hashivault/hashivault_k8s_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_config.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from ansible.module_utils.hashivault import check_auth_methods
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
@@ -73,11 +74,9 @@ def hashivault_k8s_auth_config(module):
     desired_state['mount_point'] = mount_point
 
     # check if engine is enabled
-    try:
-        if (mount_point + "/") not in client.sys.list_auth_methods():
-            return {'failed': True, 'msg': (mount_point + ' auth metod not enabled'), 'rc': 1}
-    except:
-        return {'failed': True, 'msg': (mount_point + ' error getting auth method'), 'rc': 1}
+    _, err = check_auth_methods(module, client)
+    if err:
+        return err
 
     if not module.check_mode:
         client.auth.kubernetes.configure(**desired_state)


### PR DESCRIPTION
These checks are identical,

Secrets mount:
```python
    # check if engine is enabled
    try:
        if (mount_point + "/") not in client.sys.list_mounted_secrets_engines()['data'].keys():
            return {'failed': True, 'msg': 'secret engine is not enabled', 'rc': 1}
    except:
        if module.check_mode:
            changed = True
        else:
            return {'failed': True, 'msg': 'secret engine is not enabled or namespace does not exist', 'rc': 1}
```
Auth mount:
```Python
    # check if engine is enabled
     try:
         if (mount_point + "/") not in client.sys.list_auth_methods()['data'].keys():
             return {'failed': True, 'msg': 'auth method is not enabled', 'rc': 1}
     except:
         if module.check_mode:
             changed = True
         else:
             return {'failed': True, 'msg': 'auth mount is not enabled or namespace does not exist', 'rc': 1}
```
 so I moved them in to `module_utils`, and replaced duplicates with function call