### PR TITLE
When doing state comparisons allow int/string mismatch

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -343,6 +343,11 @@ def compare_state(desired_state, current_state, ignore=None):
             if ((key not in current_state) or (not compare_state(v, current_state.get(key)))):
                 return False
         return True
+
+    # lots of things get handled as strings in ansible that aren't necessarily strings, can extend this list later.
+    if isinstance(desired_state, str) and isinstance(current_state, int):
+        current_state = str(current_state)
+
     return ((desired_state == current_state))
 
 


### PR DESCRIPTION
This is a really simple type casting to handle number/string
comparisons. I was expecting to need to cast more things than int, but
I'm not sure what else, so just do int for now and extend it as needed.

Closes: #247