### PR TITLE
Add server_flag to pki_role

### DIFF
--- a/ansible/modules/hashivault/hashivault_pki_role.py
+++ b/ansible/modules/hashivault/hashivault_pki_role.py
@@ -126,6 +126,11 @@ options:
                     - The `value` part of an element may be a `*` to allow any value with that OID
                     - Alternatively, specifying a single `*` will allow any `other_sans` input. `server_flag`
                       `(bool)` Specifies if certificates are flagged for server use.
+            server_flag:
+                type: bool
+                default: true
+                description:
+                    - Specifies if certificates are flagged for server use.
             client_flag:
                 type: bool
                 default: true


### PR DESCRIPTION
It looks like everything from the documentation except server_flag is
present in the list. It's referenced in other options so assume it's
just an ommission.

https://www.vaultproject.io/api-docs/secret/pki