### PR TITLE
Add common_name doc string to CA

### DIFF
--- a/ansible/modules/hashivault/hashivault_pki_ca.py
+++ b/ansible/modules/hashivault/hashivault_pki_ca.py
@@ -32,6 +32,10 @@ options:
             - Specifies the type of the root to create, If `exported`, the private key will be returned in the
               response;
             - If it is `internal` the private key will not be returned and cannot be retrieved later.
+    common_name:
+        type: str
+        description:
+            - Specifies the requested CN for the certificate. [required]
     kind:
         type: str
         choices: ["root", "intermediate"]


### PR DESCRIPTION
common_name is a required parameter of creating a CA and should be
mentioned in the docs.