### PR TITLE
Use the Vault client's token instead of directly taking it from params

### DIFF
--- a/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
@@ -101,9 +101,8 @@ def hashivault_oidc_auth_method_config(module):
     current_state = dict()
     exists = False
 
-    token = params['token']
     namespace = params['namespace']
-    headers = {'X-Vault-Token': token, 'X-Vault-Namespace': namespace}
+    headers = {'X-Vault-Token': client.token, 'X-Vault-Namespace': namespace}
     url = params['url']
     verify = params['verify']
 

--- a/ansible/modules/hashivault/hashivault_oidc_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_role.py
@@ -157,9 +157,8 @@ def hashivault_oidc_auth_role(module):
     current_state = dict()
     changed = False
 
-    token = params['token']
     namespace = params['namespace']
-    headers = {'X-Vault-Token': token, 'X-Vault-Namespace': namespace}
+    headers = {'X-Vault-Token': client.token, 'X-Vault-Namespace': namespace}
     url = params['url']
     verify = params['verify']
     ca_cert = params['ca_cert']


### PR DESCRIPTION
The `hashivault_oidc` modules took the token from the params. This resulted in a `missing client token` error when running it using other auth methods, such as userpass.

This PR changes the code so that `X-Vault-Token` is set using the token from the `hashivault_auth_client` instead of from the params directly.