### PR TITLE
Update default value of group_filter on hashivault_auth_ldap module

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_ldap.py
+++ b/ansible/modules/hashivault/hashivault_auth_ldap.py
@@ -125,7 +125,8 @@ def main():
     argspec['discover_dn'] = dict(required=False, type='bool', default=False)
     argspec['deny_null_bind'] = dict(required=False, type='bool', default=True)
     argspec['upn_domain'] = dict(required=False, type='str', default='')
-    argspec['group_filter'] = dict(required=False, type='str')
+    argspec['group_filter'] = dict(required=False, type='str',
+            default='(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))')
     argspec['group_attr'] = dict(required=False, type='str', default='cn')
     argspec['group_dn'] = dict(required=False, type='str', default='')
     module = hashivault_init(argspec, supports_check_mode=True)

--- a/ansible/modules/hashivault/hashivault_auth_ldap.py
+++ b/ansible/modules/hashivault/hashivault_auth_ldap.py
@@ -108,6 +108,8 @@ EXAMPLES = '''
 
 
 def main():
+    # separate long default value to pass linting
+    default_group_filter = '(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))'
     argspec = hashivault_argspec()
     argspec['description'] = dict(required=False, type='str')
     argspec['mount_point'] = dict(required=False, type='str', default='ldap')
@@ -125,8 +127,7 @@ def main():
     argspec['discover_dn'] = dict(required=False, type='bool', default=False)
     argspec['deny_null_bind'] = dict(required=False, type='bool', default=True)
     argspec['upn_domain'] = dict(required=False, type='str', default='')
-    argspec['group_filter'] = dict(required=False, type='str',
-            default='(|(memberUid={{.Username}})(member={{.UserDN}})(uniqueMember={{.UserDN}}))')
+    argspec['group_filter'] = dict(required=False, type='str', default=default_group_filter)
     argspec['group_attr'] = dict(required=False, type='str', default='cn')
     argspec['group_dn'] = dict(required=False, type='str', default='')
     module = hashivault_init(argspec, supports_check_mode=True)

--- a/functional/test_ldap_group.yml
+++ b/functional/test_ldap_group.yml
@@ -20,7 +20,7 @@
       hashivault_auth_ldap:
         ldap_url: ldap://127.0.0.1
       register: ldap_module
-    - assert: { that: "{{ ldap_module.changed }} == True" }
+    - assert: { that: "{{ ldap_module.changed }} == False" }
     - assert: { that: "{{ ldap_module.rc }} == 0" }
 
     - name: remove ldap group


### PR DESCRIPTION
Very short PR.

The goal is to fix idempotency of the module `hashivault_auth_ldap`.

The current behavior is that the changed state will be true on every run of a playbook or role using the module as long as the value for the option `group_filter` has not been set (using default).
The current default is actually not set and therefor using `None` ->https://github.com/TerryHowe/ansible-modules-hashivault/blob/master/ansible/modules/hashivault/hashivault_auth_ldap.py#L128
The documentation of the module is matching Hashicorp Vault official doc so the change was to set the default value to what would be expected.

After the fix, any run of a playbook of role using the module have a correct idempotent changed state of false if nothing was modified between the run.