### PR TITLE
hashivault_delete: adding ability to permanently delete secret for kv v2

### DIFF
--- a/ansible/modules/hashivault/hashivault_delete.py
+++ b/ansible/modules/hashivault/hashivault_delete.py
@@ -79,9 +79,15 @@ def hashivault_delete(params):
         try:
             if version == 2:
                 if permanent:
-                    returned_data = client.secrets.kv.v2.delete_metadata_and_all_versions(secret, mount_point=mount_point)
+                    returned_data = client.secrets.kv.v2.delete_metadata_and_all_versions(
+                        secret,
+                        mount_point=mount_point
+                    )
                 else:
-                    returned_data = client.secrets.kv.v2.delete_latest_version_of_secret(secret, mount_point=mount_point)
+                    returned_data = client.secrets.kv.v2.delete_latest_version_of_secret(
+                        secret,
+                        mount_point=mount_point
+                    )
             else:
                 returned_data = client.delete(secret_path)
         except InvalidPath:

--- a/ansible/modules/hashivault/hashivault_delete.py
+++ b/ansible/modules/hashivault/hashivault_delete.py
@@ -28,6 +28,10 @@ options:
     secret:
         description:
             - secret to delete.
+    permanent:
+        description:
+            - delete all versions and metadata for a given secret (only effective for kv engine version 2).
+        default: false
 extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
@@ -44,6 +48,7 @@ def main():
     argspec['version'] = dict(required=False, type='int', default=1)
     argspec['mount_point'] = dict(required=False, type='str', default='secret')
     argspec['secret'] = dict(required=True, type='str')
+    argspec['permanent'] = dict(required=False, type='bool', default=False)
     module = hashivault_init(argspec)
     result = hashivault_delete(module.params)
     if result.get('failed'):
@@ -59,6 +64,7 @@ def hashivault_delete(params):
     version = params.get('version')
     mount_point = params.get('mount_point')
     secret = params.get('secret')
+    permanent = params.get('permanent')
     if secret.startswith('/'):
         secret = secret.lstrip('/')
         mount_point = ''
@@ -72,7 +78,10 @@ def hashivault_delete(params):
         returned_data = None
         try:
             if version == 2:
-                returned_data = client.secrets.kv.v2.delete_latest_version_of_secret(secret, mount_point=mount_point)
+                if permanent:
+                    returned_data = client.secrets.kv.v2.delete_metadata_and_all_versions(secret, mount_point=mount_point)
+                else:
+                    returned_data = client.secrets.kv.v2.delete_latest_version_of_secret(secret, mount_point=mount_point)
             else:
                 returned_data = client.delete(secret_path)
         except InvalidPath:

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -19,6 +19,7 @@ ansible-playbook -v test_aws_auth_role.yml
 ansible-playbook -v test_list.yml
 ansible-playbook -v test_lookup.yml
 ansible-playbook -v test_delete.yml
+ansible-playbook -v test_delete_permanent.yml
 ansible-playbook -v test_auth.yml
 ansible-playbook -v test_auth_method.yml
 ansible-playbook -v test_azure_auth_config.yml

--- a/functional/test_delete_permanent.yml
+++ b/functional/test_delete_permanent.yml
@@ -1,0 +1,30 @@
+---
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - hashivault_write:
+        secret: test_delete_permanent
+        data:
+            uno: 'beck'
+            duo: 'clash'
+
+    - name: Make sure we can read it
+      hashivault_read:
+        secret: test_delete_permanent
+
+    - name: Delete secret
+      hashivault_delete:
+        secret: test_delete_permanent
+        permanent: true
+      register: vault_delete
+    - assert: { that: "{{vault_delete.changed}} == True" }
+    - assert: { that: "{{vault_delete.rc}} == 0" }
+    - assert: { that: "'{{vault_delete.msg}}' == 'Secret secret/test_delete_permanent deleted'" }
+
+    - name: Make sure secret value is gone
+      hashivault_read:
+        secret: test_delete_permanent
+      register: vault_read
+      failed_when: False
+    - assert: { that: "{{vault_read.changed}} == False" }
+    - assert: { that: "'{{vault_read.msg}}' == 'Secret secret/test_delete_permanent is not in vault'" }


### PR DESCRIPTION
I recently found this Ansible module and found it very useful. There was only one feature missing for my use case, and it's the ability to permanently delete a secret from the vault.

In this PR, the default behavior of keeping the history, metadata, and being able to revert a change, is not affected. What I did is add a parameter to `hashivault_delete`: `permanent`. A simple boolean, defaulting to `False`, that eventually calls the `hvac` method `delete_metadata_and_all_versions`.

There's no bug/feature filed for this. If you need one, let me know, I'll create it.