### PR TITLE
Introduce AppRole parameter secret_id_bound_cidrs

### DIFF
--- a/ansible/modules/hashivault/hashivault_approle_role.py
+++ b/ansible/modules/hashivault/hashivault_approle_role.py
@@ -30,7 +30,13 @@ options:
             - Require secret_id to be presented when logging in using this AppRole.
     bound_cidr_list:
         description:
-            - Comma-separated string or list of CIDR blocks.
+            - Deprecated. Use token_bound_cidrs instead. Comma-separated string or list of CIDR blocks.
+    token_bound_cidrs:
+        description:
+        - Comma-separated string or list of CIDR blocks.
+    secret_id_bound_cidrs:
+        description:
+        - Comma-separated string or list of CIDR blocks.
     policies:
         description:
             - policies for the role.
@@ -80,6 +86,8 @@ def main():
     argspec['mount_point'] = dict(required=False, type='str', default='approle')
     argspec['bind_secret_id'] = dict(required=False, type='bool', no_log=True)
     argspec['bound_cidr_list'] = dict(required=False, type='list')
+    argspec['token_bound_cidrs'] = dict(required=False, type='list')
+    argspec['secret_id_bound_cidrs'] = dict(required=False, type='list')
     argspec['policies'] = dict(required=False, type='list', default=[])
     argspec['secret_id_num_uses'] = dict(required=False, type='str')
     argspec['secret_id_ttl'] = dict(required=False, type='str')
@@ -103,12 +111,18 @@ def hashivault_approle_role(module):
     role_file = params.get('role_file')
     mount_point = params.get('mount_point')
     name = params.get('name')
+    bound_cidr_depr = params.get('bound_cidr_list')
+    if bound_cidr_depr is not None and len(bound_cidr_depr) > 0:
+        module.warn("parameter bound_cidr_list is deprecated, use token_bound_cidrs instead")
+        params['token_bound_cidrs'] = bound_cidr_depr
+
     client = hashivault_auth_client(params)
     if state == 'present':
         args = [
             'policies',
             'bind_secret_id',
-            'bound_cidr_list',
+            'token_bound_cidrs',
+            'secret_id_bound_cidrs',
             'secret_id_num_uses',
             'secret_id_ttl',
             'token_num_uses',

--- a/ansible/modules/hashivault/hashivault_approle_role.py
+++ b/ansible/modules/hashivault/hashivault_approle_role.py
@@ -33,10 +33,10 @@ options:
             - Deprecated. Use token_bound_cidrs instead. Comma-separated string or list of CIDR blocks.
     token_bound_cidrs:
         description:
-        - Comma-separated string or list of CIDR blocks.
+            - Comma-separated string or list of CIDR blocks.
     secret_id_bound_cidrs:
         description:
-        - Comma-separated string or list of CIDR blocks.
+            - Comma-separated string or list of CIDR blocks.
     policies:
         description:
             - policies for the role.

--- a/functional/test_approle.yml
+++ b/functional/test_approle.yml
@@ -35,6 +35,27 @@
         state: absent
       failed_when: false
 
+    - name: create role with token_bound_cidrs and secret_id_bound_cidrs
+      hashivault_approle_role:
+        name: testrole_bound_cidrs
+        token_bound_cidrs: ["127.0.0.1"]
+        secret_id_bound_cidrs: ["127.0.0.1/32"]
+        policies:
+          - approle_test_policy_original
+        state: present
+      register: 'vault_role_create_bound_cidrs'
+    - assert: { that: "{{vault_role_create_bound_cidrs.changed}} == True" }
+    - assert: { that: "{{vault_role_create_bound_cidrs.rc}} == 0" }
+
+    - name: get role with token_bound_cidrs and secret_id_bound_cidrs
+      hashivault_approle_role_get:
+        name: testrole_bound_cidrs
+      register: 'vault_role_get_bound_cidrs'
+    - assert: { that: "{{vault_role_get_bound_cidrs.changed}} == False" }
+    - assert: { that: "{{vault_role_get_bound_cidrs.rc}} == 0" }
+    - assert: { that: "'{{vault_role_get_bound_cidrs.role.data.token_bound_cidrs[0]}}' == '127.0.0.1'" }
+    - assert: { that: "'{{vault_role_get_bound_cidrs.role.data.secret_id_bound_cidrs[0]}}' == '127.0.0.1/32'" }
+
     - name: create role
       hashivault_approle_role:
         name: testrole

--- a/makedocs.sh
+++ b/makedocs.sh
@@ -8,7 +8,7 @@ git clone --branch 'v2.9.6' https://github.com/ansible/ansible.git
 pip install -r ansible/requirements.txt
 pip install sphinx sphinx_rtd_theme
 pip install straight.plugin
-pip install sphinx-notfound-page
+pip install sphinx-notfound-page==0.4
 rm -rf ansible/lib/ansible/modules/ && mkdir -p ansible/lib/ansible/modules/hashivault
 cp -r ../ansible/modules/hashivault/hashivault*.py ansible/lib/ansible/modules/hashivault/
 rm -f ansible/lib/ansible/plugins/doc_fragments/hashivault.py


### PR DESCRIPTION
Allow setting the parameter "secret_id_bound_cidrs" for an AppRole. 

While adding the parameter I found a bug: bound_cidr_list doesn't set the token_bound_cidrs parameter due to different naming. This PR includes a backwards compatible fix for the issue and adds tests.