### PR TITLE
Fix oidc modules

### DIFF
--- a/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
@@ -110,6 +110,7 @@ def hashivault_oidc_auth_method_config(module):
     for parameter in parameters:
         if params.get(parameter) is not None:
             desired_state[parameter] = params.get(parameter)
+    desired_state['path'] = mount_point
 
     changed = False
     current_state = {}

--- a/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
@@ -115,7 +115,7 @@ def hashivault_oidc_auth_method_config(module):
     changed = False
     current_state = {}
     try:
-        current_state = getattr(client.auth, 'oidc').read_config(path=mount_point)['data']
+        current_state = client.auth.oidc.read_config(path=mount_point)['data']
     except Exception:
         changed = True
     for key in desired_state.keys():
@@ -125,7 +125,7 @@ def hashivault_oidc_auth_method_config(module):
             break
 
     if changed and not module.check_mode:
-        getattr(client.auth, 'oidc').configure(**desired_state)
+        client.auth.oidc.configure(**desired_state)
     return {'changed': changed, 'old_state': current_state, 'new_state': desired_state}
 
 

--- a/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
@@ -114,7 +114,7 @@ def hashivault_oidc_auth_method_config(module):
     changed = False
     current_state = {}
     try:
-        current_state = getattr(client.auth, mount_point).read_config()['data']
+        current_state = getattr(client.auth, 'oidc').read_config(path=mount_point)['data']
     except Exception:
         changed = True
     for key in desired_state.keys():

--- a/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
@@ -119,8 +119,10 @@ def hashivault_oidc_auth_method_config(module):
     except Exception:
         changed = True
     for key in desired_state.keys():
-        if current_state.get(key, None) != desired_state[key]:
+        current_value = current_state.get(key, None)
+        if current_value is not None and current_value != desired_state[key]:
             changed = True
+            break
 
     if changed and not module.check_mode:
         getattr(client.auth, 'oidc').configure(**desired_state)

--- a/ansible/modules/hashivault/hashivault_oidc_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_role.py
@@ -194,8 +194,10 @@ def hashivault_oidc_auth_role(module):
     except Exception:
         changed = True
     for key in desired_state.keys():
-        if current_state.get(key, None) != desired_state[key]:
+        current_value = current_state.get(key, None)
+        if current_value is not None and current_value != desired_state[key]:
             changed = True
+            break
 
     if changed and not module.check_mode:
         if not current_state and state == 'present':

--- a/ansible/modules/hashivault/hashivault_oidc_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_role.py
@@ -189,7 +189,7 @@ def hashivault_oidc_auth_role(module):
     changed = False
     current_state = {}
     try:
-        current_state = getattr(client.auth, mount_point).read_role(name=name)['data']
+        current_state = getattr(client.auth, 'oidc').read_role(name=name, path=mount_point)['data']
     except Exception:
         changed = True
     for key in desired_state.keys():

--- a/ansible/modules/hashivault/hashivault_oidc_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_role.py
@@ -190,7 +190,7 @@ def hashivault_oidc_auth_role(module):
     changed = False
     current_state = {}
     try:
-        current_state = getattr(client.auth, 'oidc').read_role(name=name, path=mount_point)['data']
+        current_state = client.auth.oidc.read_role(name=name, path=mount_point)['data']
     except Exception:
         changed = True
     for key in desired_state.keys():
@@ -201,9 +201,9 @@ def hashivault_oidc_auth_role(module):
 
     if changed and not module.check_mode:
         if not current_state and state == 'present':
-            getattr(client.auth, 'oidc').create_role(name=name, **desired_state)
+            client.auth.oidc.create_role(name=name, **desired_state)
         elif current_state and state == 'absent':
-            getattr(client.auth, 'oidc').delete_role(name=name)
+            client.auth.oidc.delete_role(name=name)
     return {'changed': changed, 'old_state': current_state, 'new_state': desired_state}
 
 

--- a/ansible/modules/hashivault/hashivault_oidc_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_role.py
@@ -185,6 +185,7 @@ def hashivault_oidc_auth_role(module):
     if not desired_state['token_policies'] and desired_state['policies']:
         desired_state['token_policies'] = desired_state['policies']
     desired_state.pop('policies', None)
+    desired_state['path'] = mount_point
 
     changed = False
     current_state = {}


### PR DESCRIPTION
This pull request fixes these bugs:
- `mount_point` is ignored
- the `old_state` is always `{}`
- the logic to detect changes can fail

Changed modules:
- hashivault_oidc_auth_method_config
- hashivault_oidc_auth_role
