### PR TITLE
Fix logic to detect changes in k8s auth config

### DIFF
--- a/ansible/modules/hashivault/hashivault_k8s_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_config.py
@@ -84,7 +84,7 @@ def hashivault_k8s_auth_config(module):
     keys_updated = desired_state.keys()
     try:
         current_state = client.auth.kubernetes.read_config(mount_point=mount_point)
-        keys_updated = get_keys_updated(current_state, desired_state)
+        keys_updated = get_keys_updated(desired_state, current_state)
         if not keys_updated:
             return {'changed': False}
     except InvalidPath:

--- a/ansible/modules/hashivault/hashivault_k8s_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_config.py
@@ -81,10 +81,15 @@ def hashivault_k8s_auth_config(module):
         desired_state['issuer'] = params.get('issuer')
     desired_state['mount_point'] = mount_point
 
+    ignore_list = [
+        'mount_point',
+        'token_reviewer_jwt',
+        'pem_keys'
+    ]
     keys_updated = desired_state.keys()
     try:
         current_state = client.auth.kubernetes.read_config(mount_point=mount_point)
-        keys_updated = get_keys_updated(desired_state, current_state)
+        keys_updated = get_keys_updated(desired_state, current_state, ignore_list)
         if not keys_updated:
             return {'changed': False}
     except InvalidPath:

--- a/ansible/modules/hashivault/hashivault_k8s_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_config.py
@@ -89,8 +89,15 @@ def hashivault_k8s_auth_config(module):
     keys_updated = desired_state.keys()
     try:
         current_state = client.auth.kubernetes.read_config(mount_point=mount_point)
-        keys_updated = get_keys_updated(desired_state, current_state, ignore_list)
-        if not keys_updated:
+        key_updated = get_keys_updated(desired_state, current_state, ignore_list)
+        if desired_state['pem_keys'] is not None:
+            is_pem_keys_changed = set(desired_state['pem_keys']) != set(current_state['pem_keys'])
+        elif current_state['pem_keys'] != []:
+            is_pem_keys_changed = True
+        else:
+            is_pem_keys_changed = False
+
+        if not keys_updated and not is_pem_keys_changed:
             return {'changed': False}
     except InvalidPath:
         pass


### PR DESCRIPTION
Fix typo and logic to detect changes in k8s auth config

Summary
- `kubernetes_reviewer_jwt` and `mount_point` fields do not appear in `current_state`
- `pem_keys` in `desired_state` can be `None`