### PR TITLE
Support verified rekeys

### DIFF
--- a/ansible/modules/hashivault/hashivault_rekey_init.py
+++ b/ansible/modules/hashivault/hashivault_rekey_init.py
@@ -43,6 +43,7 @@ def main():
     argspec['secret_threshold'] = dict(required=False, type='int', default=3)
     argspec['pgp_keys'] = dict(required=False, type='list', default=[], no_log=True)
     argspec['backup'] = dict(required=False, type='bool', default=False)
+    argspec['verification_required'] = dict(required=False, type='bool', default=False)
     module = hashivault_init(argspec)
     result = hashivault_rekey_init(module.params)
     if result.get('failed'):
@@ -62,7 +63,9 @@ def hashivault_rekey_init(params):
     secret_threshold = params.get('secret_threshold')
     pgp_keys = params.get('pgp_keys')
     backup = params.get('backup')
-    return {'status': client.sys.start_rekey(secret_shares, secret_threshold, pgp_keys, backup), 'changed': True}
+    verification_required = params.get('verification_required')
+    return {'status': client.sys.start_rekey(secret_shares, secret_threshold, pgp_keys, backup, verification_required),
+            'changed': True}
 
 
 if __name__ == '__main__':

--- a/ansible/modules/hashivault/hashivault_rekey_verify.py
+++ b/ansible/modules/hashivault/hashivault_rekey_verify.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_client
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+
+ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
+DOCUMENTATION = '''
+---
+module: hashivault_rekey_verify
+version_added: "4.6.1"
+short_description: Hashicorp Vault rekey verify module
+description:
+    - Module to verify a rekey of Hashicorp Vault. Requires that a rekey
+      be started with hashivault_rekey_init passing verification_required == True
+      and being successfully completed.
+options:
+    key:
+        description:
+            - vault key shard (aka unseal key). The new, freshly generated one.
+    nonce:
+        description:
+            - verify nonce.
+extends_documentation_fragment: hashivault
+'''
+EXAMPLES = '''
+---
+- hosts: localhost
+  tasks:
+    - hashivault_rekey_verify:
+      key: '{{vault_key}}'
+      nonce: '{{nonce}}'
+'''
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec['key'] = dict(required=True, type='str', no_log=True)
+    argspec['nonce'] = dict(required=True, type='str')
+    module = hashivault_init(argspec)
+    result = hashivault_rekey_verify(module.params)
+    if result.get('failed'):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_rekey_verify(params):
+    key = params.get('key')
+    nonce = params.get('nonce')
+    client = hashivault_client(params)
+    return {'status': client.sys.rekey_verify(key, nonce), 'changed': True}
+
+
+if __name__ == '__main__':
+    main()

--- a/functional/run.sh
+++ b/functional/run.sh
@@ -51,12 +51,17 @@ ansible-playbook -v test_audit_old.yml
 ansible-playbook -v test_read_write_file.yml
 ansible-playbook -v test_environment_lookup.yml
 ansible-playbook -v test_unseal.yml
-ansible-playbook -v test_rekey.yml
 ansible-playbook -v test_identity_group.yml
 ansible-playbook -v test_identity_entity.yml
 ansible-playbook -v test_ldap_group.yml
 ansible-playbook -v test_pki.yml
+ansible-playbook -v test_rekey.yml
 # test_rekey.yml changes unseal keys, need to update VAULT_KEYS
+# for further test, if any.
+source ./vaultenv.sh
+
+ansible-playbook -v test_rekey_verify.yml
+# test_rekey_verify.yml changes unseal keys, need to update VAULT_KEYS
 # for further test, if any.
 source ./vaultenv.sh
 

--- a/functional/test_rekey_verify.yml
+++ b/functional/test_rekey_verify.yml
@@ -22,12 +22,13 @@
       hashivault_rekey_init:
         secret_shares: 1
         secret_threshold: 1
+        verification_required: True
       register: 'vault_rekey_init'
     - assert: { that: "{{vault_rekey_init.changed}} == True" }
     - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
     - assert: { that: "{{vault_rekey_init.status.started}} == True" }
     - assert: { that: "{{vault_rekey_init.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.verification_required}} == False" }
+    - assert: { that: "{{vault_rekey_init.status.verification_required}} == True" }
 
     - name: Make sure the rekey started
       hashivault_rekey_status:
@@ -47,12 +48,13 @@
       hashivault_rekey_init:
         secret_shares: 1
         secret_threshold: 1
+        verification_required: True
       register: 'vault_rekey_init'
     - assert: { that: "{{vault_rekey_init.changed}} == True" }
     - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
     - assert: { that: "{{vault_rekey_init.status.started}} == True" }
     - assert: { that: "{{vault_rekey_init.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.verification_required}} == False" }
+    - assert: { that: "{{vault_rekey_init.status.verification_required}} == True" }
 
     - name: Update the rekey
       hashivault_rekey:
@@ -62,7 +64,17 @@
     - assert: { that: "{{vault_rekey.changed}} == True" }
     - assert: { that: "{{vault_rekey.rc}} == 0" }
     - assert: { that: "{{vault_rekey.status.complete}} == True" }
-    - assert: { that: "{{vault_rekey.status.verification_required}} == False" }
+    - assert: { that: "{{vault_rekey.status.verification_required}} == True" }
+
+    - name: Verify the rekey
+      hashivault_rekey_verify:
+        key: "{{ vault_rekey['status']['keys'][0] }}"
+        nonce: "{{ vault_rekey.status.verification_nonce }}"
+      register: 'vault_rekey_verify'
+    - assert: { that: "{{vault_rekey_verify.changed}} == True" }
+    - assert: { that: "{{vault_rekey_verify.rc}} == 0" }
+    - assert: { that: "{{vault_rekey_verify.status.complete}} == True" }
+    - assert: { that: "'{{vault_rekey_verify.status.nonce}}' == '{{vault_rekey.status.verification_nonce}}'" }
 
     - name: Update vaultenv.sh with new keys
       lineinfile:


### PR DESCRIPTION
Vault has a possibility to delay putting a rekey in effect until the new
unseal keys are verified by providing a threshold of them to the rekey
endpoint. Support this scheme in the module.