### PR TITLE
Add support for UNIX Socket in VAULT_ADDR and test cases

### DIFF
--- a/functional/run.sh
+++ b/functional/run.sh
@@ -40,6 +40,7 @@ ansible-playbook -v test_azure_config.yml
 ansible-playbook -v test_policy.yml
 ansible-playbook -v test_policy_old.yml
 ansible-playbook -v test_status.yml
+ansible-playbook -v test_agent_socket.yml
 ansible-playbook -v test_not_there.yml
 ansible-playbook -v test_ephemeral.yml
 ansible-playbook -v test_generate_root.yml

--- a/functional/start.sh
+++ b/functional/start.sh
@@ -4,11 +4,17 @@
 #
 set -e
 DOCKER_NAME=testvault
+DOCKER_AGENT_NAME=testvaultagent
 PORT=8201
+AGENTPORT=8208
 export VAULT_ADDR="http://127.0.0.1:${PORT}"
+
+export AGENT_SOCK_DIR=$(mktemp -q -d /tmp/$0.agentsockdir.XXXXXX)
+export VAULT_AGENT_ADDR_SOCK=${AGENT_SOCK_DIR}/agent.sock
 
 TMP_CONFIG_DIR=$(mktemp -q -d /tmp/$0.XXXXXX)
 TMP_CONFIG_VAULT="${TMP_CONFIG_DIR}/vault.json"
+TMP_CONFIG_AGENT="${TMP_CONFIG_DIR}/agent.hcl"
 trap "rm -rf $TMP_CONFIG_DIR" EXIT
 
 cat <<EOF > $TMP_CONFIG_VAULT
@@ -52,6 +58,51 @@ while ! curl -sI "$VAULT_ADDR/v1/sys/health" > /dev/null; do
 		exit 1
 	fi
 done
+
+
+cat <<EOF > $TMP_CONFIG_AGENT
+vault {
+	address = "$VAULT_ADDR"
+}
+listener "tcp" {
+	address = "0.0.0.0:$AGENTPORT"
+	tls_disable = true
+}
+listener "unix" {
+	address = "/agentsockdir/agent.sock"
+	tls_disable = true
+}
+cache {}
+EOF
+chmod a+r $TMP_CONFIG_AGENT
+chmod 0777 $AGENT_SOCK_DIR
+touch $AGENT_SOCK_DIR/agent.sock
+
+docker stop $DOCKER_AGENT_NAME 2>/dev/null || true
+docker rm $DOCKER_AGENT_NAME 2>/dev/null || true
+docker run --name $DOCKER_AGENT_NAME -h $DOCKER_AGENT_NAME -d \
+    --cap-add IPC_LOCK \
+	-v $AGENT_SOCK_DIR:/agentsockdir/:rw \
+	-v $TMP_CONFIG_AGENT:/etc/vault/agent.hcl:ro \
+	--network host \
+	vault agent -config /etc/vault/agent.hcl
+
+#
+# Wait for vault agent to come up
+#
+CNT=0
+while ! curl -sI "http://127.0.0.1:$AGENTPORT/v1/sys/health" > /dev/null; do
+	sleep 1
+	CNT=$(expr $CNT + 1)
+	if [ $CNT -gt 20 ]
+	then
+		docker logs $DOCKER_AGENT_NAME
+		exit 1
+	fi
+done
+
+# Make the socket world accessible.
+docker exec $DOCKER_AGENT_NAME chmod -R 'ugo+rwX' /agentsockdir
 
 #
 # Initialize the vault

--- a/functional/start.sh
+++ b/functional/start.sh
@@ -35,8 +35,8 @@ docker stop $DOCKER_NAME 2>/dev/null || true
 docker rm $DOCKER_NAME 2>/dev/null || true
 docker run --name $DOCKER_NAME -h $DOCKER_NAME -d \
     --cap-add IPC_LOCK \
-	-p 127.0.0.1:${PORT}:${PORT} \
 	-v $TMP_CONFIG_VAULT:/etc/vault/config.json:ro \
+	--network host \
 	vault server -config /etc/vault/config.json
 
 #

--- a/functional/start.sh
+++ b/functional/start.sh
@@ -43,7 +43,7 @@ docker run --name $DOCKER_NAME -h $DOCKER_NAME -d \
 #
 CNT=0
 while ! curl -sI "$VAULT_ADDR/v1/sys/health" > /dev/null; do
-	sleep 0.1
+	sleep 1
 	CNT=$(expr $CNT + 1)
 	if [ $CNT -gt 20 ]
 	then

--- a/functional/stop.sh
+++ b/functional/stop.sh
@@ -3,5 +3,7 @@
 # Stop the test vault container
 #
 export NAME=${NAME:-test_vault}
+export AGENTNAME=${NAME:-testvaultagent}
 docker stop $NAME 2>/dev/null || true
+docker stop $AGENTNAME 2>/dev/null || true
 rm -f ./vaultenv.sh approlenv.sh

--- a/functional/templates/vaultenv.sh.j2
+++ b/functional/templates/vaultenv.sh.j2
@@ -1,6 +1,7 @@
 export VAULT_ADDR='{{lookup('env','VAULT_ADDR')}}'
 export VAULT_TOKEN='{{vault_init['root_token']}}'
 export VAULT_KEYS='{{vault_init['keys'] | join(' ')}}'
+export VAULT_AGENT_ADDR_SOCK='{{lookup('env','VAULT_AGENT_ADDR_SOCK')}}'
 unset VAULT_AUTHTYPE
 unset VAULT_LOGIN_MOUNT_POINT
 unset VAULT_USER

--- a/functional/test_agent_socket.yml
+++ b/functional/test_agent_socket.yml
@@ -1,0 +1,12 @@
+- hosts: localhost
+  gather_facts: no
+  vars:
+    sock: "{{ lookup('env', 'VAULT_AGENT_ADDR_SOCK') }}"
+  tasks:
+    - assert: { that: "{{sock|count}} > 0" }
+    - name: Get vault status via Vault Agent socket
+      environment:
+        VAULT_ADDR: "http+unix://{{ sock }}"
+      hashivault_status:
+      register: 'vault_status'
+    - assert: { that: "{{vault_status.rc}} == 0" }

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ setenv =
     LC_ALL=C
 whitelist_externals = bash
 commands = bash -ex {toxinidir}/functional/run.sh
+sitepackages = True
 
 [testenv:venv]
 commands = {posargs}


### PR DESCRIPTION
This pull request seeks to resolve #319 , which raises that HVAC does not *directly* support UNIX sockets, but has a clean workaround, by using `requests_unixsocket` to open a `Session` on the socket ahead of constructing the HVAC `Client`. This pull request implements that change in fcac9cc3ec6b88b1b148aac6c3704757d591b686.

All other commits are in support of the testing environment (to which I had to add Vault Agent, in order to support the test case) and the test case itself.

Please note, the new test requires `requests_unixsocket` to be available on the execution host, but that import is not made unless a `VAULT_ADDR` with `unix` in the scheme is supplied.