### PR TITLE
Update hashivault_userpass example to use newer module

### DIFF
--- a/ansible/modules/hashivault/hashivault_userpass.py
+++ b/ansible/modules/hashivault/hashivault_userpass.py
@@ -44,10 +44,10 @@ EXAMPLES = '''
 ---
 - hosts: localhost
   tasks:
-    - hashivault_userpass_create:
-      name: 'bob'
-      pass: 'S3cre7s'
-      policies: 'bob'
+    - hashivault_userpass:
+        name: 'bob'
+        pass: 'S3cre7s'
+        policies: 'bob'
 '''
 
 


### PR DESCRIPTION
The example in the `hashivault_userpass` documentation was using `hashivault_userpass_create` which appears to be deprecated. Also fixes small indentation issue.