### PR TITLE
Fix hashivault_audit_list `changed` state

### DIFF
--- a/ansible/modules/hashivault/hashivault_audit_list.py
+++ b/ansible/modules/hashivault/hashivault_audit_list.py
@@ -37,7 +37,7 @@ def hashivault_audit_list(params):
     client = hashivault_auth_client(params)
     backends = client.sys.list_enabled_audit_devices()
     backends = backends.get('data', backends)
-    return {'changed': True, 'backends': backends}
+    return {'changed': False, 'backends': backends}
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Make hashivault_audit_list always return as unchanged/OK, since it never
changes Vault state. This behavior is consistent with other
reading/listing modules, e.g. hashivault_approle_role_list.