### PR TITLE
Use list_secrets function by default for modern Vault versions

### DIFF
--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -91,11 +91,11 @@ def hashivault_list(params):
 
     try:
         if version == 2:
-            if secret:
+            if 'metadata' in secret:
                 response = client.secrets.kv.v2.read_secret_metadata(path=secret, mount_point=mount_point)
                 result['metadata'] = response.get('data', {})
             else:
-                response = client.secrets.kv.v2.list_secrets('', mount_point=mount_point)
+                response = client.secrets.kv.v2.list_secrets(path=secret, mount_point=mount_point)
                 result['secrets'] = response.get('data', {}).get('keys', [])
         else:
             response = client.secrets.kv.v1.list_secrets(path=secret, mount_point=mount_point)


### PR DESCRIPTION
Module hashivault_list don't works corectly with modern Vault servers (in my environment vault-1.6.2)

Vault don't return list of secrets for subkey path with function `client.secrets.kv.v2.read_secret_metadata`
This small playbook currently return error:
```bash
---
- hosts: localhost

  roles:
    - ansible-modules-hashivault

  tasks:
    ### ------------  DEBUG ---------- ###
    - hashivault_write:
        secret: 'list/one'
        url: "https://vault.query.consul.local"
        data:
          tuesday: 'tuesday'
        version: 2
        mount_point: kv  
    - hashivault_write:
        secret: 'list/two'
        url: "https://vault.query.consul.local"
        data:
          wednesday: 'threde'
        version: 2
        mount_point: kv


    - name: List secrets in folder full path levels
      hashivault_list:
        secret: 'list'
        url: "https://vault.query.consul.local"
        mount_point: kv
        version: 2
      register: vault_list
    - assert: { that: vault_list.rc == 0 }
      
    - name: debug result
      debug:
        var: vault_list
```

Error:
```bash
PLAY [localhost] ****************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************************
ok: [localhost]

TASK [hashivault_write] *********************************************************************************************************************************************************************************************
changed: [localhost]

TASK [hashivault_write] *********************************************************************************************************************************************************************************************
changed: [localhost]

TASK [List secrets in folder full path levels] **********************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => changed=false 
  msg: 'Secret does not exist: kv/list'
  rc: 1
```

This PR fix this error.
As result will be correctly returned secrets list:
```bash
PLAY [localhost] ****************************************************************************************************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************************************************************************************************
ok: [localhost]

TASK [hashivault_write] *********************************************************************************************************************************************************************************************
changed: [localhost]

TASK [hashivault_write] *********************************************************************************************************************************************************************************************
changed: [localhost]

TASK [List secrets in folder full path levels] **********************************************************************************************************************************************************************
ok: [localhost]

TASK [assert] *******************************************************************************************************************************************************************************************************
ok: [localhost] => changed=false 
  msg: All assertions passed

TASK [debug result] *************************************************************************************************************************************************************************************************
ok: [localhost] => 
  vault_list:
    changed: false
    failed: false
    rc: 0
    secrets:
    - one
    - two
```