### PR TITLE
pep8 fixes

### DIFF
--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -92,7 +92,6 @@ def hashivault_list(params):
     else:
         metadata = False
 
-
     try:
         if version == 2:
             if secret and metadata:

--- a/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
@@ -55,7 +55,8 @@ options:
               Discovery URL. If not set, system certificates are used.
     provider_config:
         description:
-            - Configuration options for provider-specific handling. Providers with specific handling include: Azure, Google.
+            - "Configuration options for provider-specific handling.
+              Providers with specific handling include: Azure, Google."
 extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''

--- a/ansible/modules/hashivault/hashivault_userpass.py
+++ b/ansible/modules/hashivault/hashivault_userpass.py
@@ -88,7 +88,7 @@ def hashivault_userpass_update(client, user_details, user_name, user_pass, user_
 
     if password_change_allowed and attribute_changed:
         client.auth.userpass.create_or_update_user(user_name, user_pass, user_policies, mount_point=mount_point,
-                               token_bound_cidrs=token_bound_cidrs)
+                                                   token_bound_cidrs=token_bound_cidrs)
         return {'changed': True}
 
     if not password_change_allowed and attribute_changed:
@@ -122,8 +122,9 @@ def hashivault_userpass(params):
             user_details = client.auth.userpass.read_user(name, mount_point=mount_point)
         except Exception:
             if password is not None:
-                client.auth.userpass.create_or_update_user(name, password, policies, token_bound_cidrs=token_bound_cidrs,
-                                       mount_point=mount_point)
+                client.auth.userpass.create_or_update_user(name, password, policies,
+                                                           token_bound_cidrs=token_bound_cidrs,
+                                                           mount_point=mount_point)
                 return {'changed': True}
             else:
                 return {'failed': True, 'msg': 'pass must be provided for new users'}


### PR DESCRIPTION
A few code style fixes.

```
$ pycodestyle --max-line-length=120 ansible
ansible/modules/hashivault/hashivault_list.py:96:5: E303 too many blank lines (2)
ansible/modules/hashivault/hashivault_oidc_auth_method_config.py:58:121: E501 line too long (124 > 120 characters)
ansible/modules/hashivault/hashivault_userpass.py:91:32: E128 continuation line under-indented for visual indent
ansible/modules/hashivault/hashivault_userpass.py:125:121: E501 line too long (121 > 120 characters)
ansible/modules/hashivault/hashivault_userpass.py:126:40: E128 continuation line under-indented for visual indent
```
