### PR TITLE
Add token_type option to k8s_auth_role

### DIFF
--- a/ansible/modules/hashivault/hashivault_k8s_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_role.py
@@ -39,6 +39,12 @@ options:
         description:
             - File with a json object containing play parameters. pass all params but name, state, mount_point which
               stay in the ansible play
+    token_type:
+        description:
+            - The type of token that should be generated. Can be service, batch, or default to use the mount's tuned
+              default (which unless changed will be service tokens). For token store roles, there are two additional
+              possibilities (default-service and default-batch) which specify the type to return unless the client
+              requests a different type at generation time.
 extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
@@ -68,6 +74,7 @@ def main():
     argspec['period'] = dict(required=False, type='int', default=0)
     argspec['mount_point'] = dict(required=False, type='str', default='kubernetes')
     argspec['role_file'] = dict(required=False, type='str')
+    argspec['token_type'] = dict(required=False, type='str', default='default')
     argspec['state'] = dict(required=False, type='str', default='present', choices=['present', 'absent'])
 
     module = hashivault_init(argspec, supports_check_mode=True)
@@ -84,6 +91,7 @@ def hashivault_k8s_auth_role(module):
     client = hashivault_auth_client(params)
     mount_point = params.get('mount_point').strip('/')
     role_file = params.get('role_file')
+    token_type = params.get('token_type')
     name = params.get('name').strip('/')
     state = params.get('state')
     desired_state = dict()
@@ -99,6 +107,7 @@ def hashivault_k8s_auth_role(module):
         desired_state['max_ttl'] = params.get('max_ttl')
         desired_state['period'] = params.get('period')
         desired_state['policies'] = params.get('policies')
+        desired_state['token_type'] = params.get('token_type')
 
     # check if role exists
     try:

--- a/functional/test_k8_auth.yml
+++ b/functional/test_k8_auth.yml
@@ -50,8 +50,22 @@
         policies: ["test", "test2"]
         bound_service_account_names: ["vault-auth"]
         bound_service_account_namespaces: ["default", "some-app"]
+        token_type: service
       register: k8s_module
     - assert: { that: "{{ k8s_module.changed }} == True" }
+    - assert: { that: "{{ k8s_module.rc }} == 0" }
+
+    - name: read role
+      hashivault_read:
+        secret: "kubernetes/role/testk8srole"
+        mount_point: "auth"
+      register: k8s_module
+    - assert:
+        that:
+          - k8s_module.value.policies|sort == ["test","test2"]|sort
+          - k8s_module.value.bound_service_account_names|sort == ["vault-auth"]|sort
+          - k8s_module.value.bound_service_account_namespaces|sort == ["some-app","default"]|sort
+          - k8s_module.value.token_type == 'service'
     - assert: { that: "{{ k8s_module.rc }} == 0" }
 
     - name: create role idempotent
@@ -60,6 +74,7 @@
         policies: ["test", "test2"]
         bound_service_account_names: ["vault-auth"]
         bound_service_account_namespaces: ["default", "some-app"]
+        token_type: service
       register: k8s_module
     - assert: { that: "{{ k8s_module.changed }} == False" }
     - assert: { that: "{{ k8s_module.rc }} == 0" }

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=files,
     install_requires=[
         'ansible>=4.0.0',
-        'hvac>=0.11.0',
+        'hvac>=0.11.2',
         'requests',
     ],
 )


### PR DESCRIPTION
closes #356 

Add the ```token_type``` option the ```hashivault_k8s_auth_role``` module.

Requires hvac 0.11.2 which also adds it to the k8s API via hvac/hvac#760