### PR TITLE
Add Github Actions Test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install requirements
+        run: pip install -r test-requirements.txt
+
+      - name: Lint with pycodestyle
+        run: pycodestyle --max-line-length=120 ansible
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 2.7
+          - 3.6
+          - 3.7
+          - 3.8
+          - 3.9
+
+    steps:
+      - uses: "actions/checkout@v2"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install requirements
+        run: pip install -r test-requirements.txt tox-gh-actions
+
+      - name: Run tox
+        run: tox
+
+  docs:
+    name: Documentation Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Make docs
+        run: ./makedocs.sh

--- a/makedocs.sh
+++ b/makedocs.sh
@@ -4,11 +4,8 @@ export PLUGINS=''
 rm -rf ansible-repo
 mkdir -p ansible-repo
 cd ansible-repo
-git clone --branch 'v2.9.6' https://github.com/ansible/ansible.git
+git clone --branch 'v2.9.26' https://github.com/ansible/ansible.git
 pip install -r ansible/requirements.txt
-pip install sphinx sphinx_rtd_theme
-pip install straight.plugin
-pip install sphinx-notfound-page==0.4
 rm -rf ansible/lib/ansible/modules/ && mkdir -p ansible/lib/ansible/modules/hashivault
 cp -r ../ansible/modules/hashivault/hashivault*.py ansible/lib/ansible/modules/hashivault/
 rm -f ansible/lib/ansible/plugins/doc_fragments/hashivault.py
@@ -16,6 +13,7 @@ cp {..,ansible/lib}/ansible/plugins/doc_fragments/hashivault.py
 ls ansible/lib/ansible/modules/hashivault
 export MODULES=$(ls -m ansible/lib/ansible/modules/hashivault/ | grep -v '^_' | tr -d '[:space:]' | sed 's/.py//g')
 cd ansible/docs/docsite/
+pip install -r requirements.txt
 rm -f $(find . -name developing_modules_general_windows.rst)
 make webdocs || true
 touch _build/html/.nojekyll

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 pycodestyle==2.5.0
-tox==3.7.0
+tox==3.24.2
 sphinx
 sphinx_rtd_theme

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,18 @@
 [tox]
-envlist = pep8,py27,py36
+envlist = pep8,py27,py36,py37,py38,py39
+
+[gh-actions]
+python =
+    2.7: py27
+    3.6: py36
+    3.7: py37
+    3.8: py38
+    3.9: py39
 
 [testenv]
 install_command = pip install {opts} {packages}
 setenv =
     VIRTUAL_ENV={envdir}
-    LANG=en_US.UTF-8
-    LANGUAGE=en_US:en
-    LC_ALL=C
 whitelist_externals = bash
 commands = bash -ex {toxinidir}/functional/run.sh
 
@@ -18,9 +23,6 @@ commands = {posargs}
 install_command = pip install {opts} {packages}
 setenv =
     VIRTUAL_ENV={envdir}
-    LANG=en_US.UTF-8
-    LANGUAGE=en_US:en
-    LC_ALL=C
 deps = pycodestyle==2.5.0
 commands =
     pycodestyle --max-line-length=120 --statistics ansible
@@ -28,8 +30,5 @@ commands =
 [testenv:docs]
 setenv =
     VIRTUAL_ENV={envdir}
-    LANG=en_US.UTF-8
-    LANGUAGE=en_US:en
-    LC_ALL=C
 commands =
     ./makedocs.sh 


### PR DESCRIPTION
I noticed the Travis CI jobs were no longer being run. I'm not sure if you had other plans, but I created a Github actions workflow that could be used.

1. makedocs.sh was failing with latest version of ```Sphinx``` so updated to only install requirements from ansible 2.9.26 repo which restricts the version.
2. Python3.6 was failing with newer versions of pip. Rather than downgrade, updated tox version 3.24.2 and removed ```LANG```, ```LANGUAGE```, and ```LC_ALL``` from tox configuration which implicitly adds to passenv.