### PR TITLE
Return secret version when reading kv v2 secret

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -183,11 +183,13 @@ def hashivault_read(params):
     if version == 2:
         try:
             data = response.get('data', {})
+            metadata = data.get('metadata', {})
             data = data.get('data', {})
         except Exception:
             data = str(response)
     else:
         data = response['data']
+        metadata = {}
     lease_duration = response.get('lease_duration', None)
     if lease_duration is not None:
         result['lease_duration'] = lease_duration
@@ -213,6 +215,7 @@ def hashivault_read(params):
     else:
         value = data
     result['value'] = value
+    result['metadata'] = metadata
     return result
 
 


### PR DESCRIPTION
Prior to this change, it wasn't possible to update a secret stored in KV
v2 secrets engine because hashivault_read doesn't return secret's
version. This fix adds secret's metadata to the return value of
hashivault_read.

Signed-off-by: Albin Kerouanton <albinker@gmail.com>