### PR TITLE
Fix auth_method idempotency

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -101,12 +101,8 @@ def hashivault_auth_method(module):
     elif state == 'disabled' and exists:
         changed = True
     elif exists and state == 'enabled':
-        current_state = client.sys.read_auth_method_tuning(path=mount_point)['data']
-        if 'description' in current_state:
-            if description != current_state['description']:
-                changed = True
-        if not changed:
-            changed = is_state_changed(config, current_state)
+        current_state = auth_methods[mount_point + u"/"]
+        changed = description != current_state['description'] or is_state_changed(config, current_state['config'])
 
     if module.check_mode:
         return {'changed': changed, 'created': create, 'state': state}

--- a/functional/test_auth_method.yml
+++ b/functional/test_auth_method.yml
@@ -34,6 +34,9 @@
       hashivault_auth_method:
         method_type: oidc
         state: enabled
+        config:
+          default_lease_ttl: 0
+          max_lease_ttl: 0
       register: oidc_idempotent
     - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
     - assert: { that: "{{ oidc_idempotent.changed }} == True" }
@@ -42,6 +45,9 @@
       hashivault_auth_method:
         method_type: oidc
         state: enabled
+        config:
+          default_lease_ttl: 0
+          max_lease_ttl: 0
       register: oidc_idempotent
     - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
     - assert: { that: "{{ oidc_idempotent.changed }} == False" }
@@ -50,6 +56,9 @@
       hashivault_auth_method:
         method_type: oidc
         state: enabled
+        config:
+          default_lease_ttl: 0
+          max_lease_ttl: 0
         description: 'my oidc'
       register: oidc_idempotent
     - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
@@ -59,6 +68,9 @@
       hashivault_auth_method:
         method_type: oidc
         state: enabled
+        config:
+          default_lease_ttl: 0
+          max_lease_ttl: 0
         description: 'my oidc'
       register: oidc_idempotent
     - assert: { that: "{{ oidc_idempotent.rc }} == 0" }


### PR DESCRIPTION
Resolves #382 

The list auth methods and read auth method tuning return different values for the default_lease_ttl and max_lease_ttl when the user configures them as "0". The list method will return "0" but the read auth method tuning will return the effective values (the default_lease_ttl and max_lease_ttl in the server configuration). The Vault UI also uses the values from the list auth methods to display the auth method configurations rather than the read auth method tuning.