### PR TITLE
add a hashivault_token_role_list module

### DIFF
--- a/ansible/modules/hashivault/hashivault_token_role_list.py
+++ b/ansible/modules/hashivault/hashivault_token_role_list.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+from ansible.module_utils.hashivault import hashivault_auth_client
+from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_init
+from ansible.module_utils.hashivault import hashiwrapper
+from hvac.exceptions import InvalidPath
+
+ANSIBLE_METADATA = {
+    "status": ["preview"],
+    "supported_by": "community",
+    "version": "1.1",
+}
+DOCUMENTATION = r"""
+---
+module: hashivault_token_role_list
+version_added: "4.7.0"
+short_description: Hashicorp Vault Token List Roles
+description:
+    - This module returns a list of available token roles.
+    - Only the role names are returned, not any values.
+options:
+    mount_point:
+        default: token
+        description:
+            - location where the token auth engine is mounted. also known as path
+extends_documentation_fragment:
+    - hashivault
+"""
+EXAMPLES = r"""
+---
+- hosts: localhost
+  tasks:
+    - hashivault_token_role_list:
+        mount_point: token
+      register: roles_list
+    - debug: msg="{{ roles_list.data }}"
+"""
+RETURN = r"""
+---
+data:
+    description: list of roles, if auth token engine has no roles will return empty list
+    returned: success
+    type: list
+"""
+
+
+def main():
+    argspec = hashivault_argspec()
+    argspec["mount_point"] = dict(required=False, type="str", default="token")
+
+    module = hashivault_init(argspec, supports_check_mode=True)
+    result = hashivault_token_role_list(module)
+
+    if result.get("failed"):
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+@hashiwrapper
+def hashivault_token_role_list(module):
+    params = module.params
+    client = hashivault_auth_client(params)
+
+    mount_point = params.get("mount_point").strip("/")
+
+    try:
+        return {
+            "data": client.auth.token.list_roles(mount_point=mount_point)
+            .get("data")
+            .get("keys")
+        }
+    except InvalidPath as exc:
+        if len(exc.errors) == 0:  # Path is valid but no roles exist.
+            return {"data": []}
+        return {"failed": True, "data": [], "msg": str(exc)}
+    except Exception as exc:
+        return {"failed": True, "data": [], "msg": str(exc)}
+
+
+if __name__ == "__main__":
+    main()

--- a/functional/test_token_role.yml
+++ b/functional/test_token_role.yml
@@ -31,6 +31,13 @@
         state: absent
       failed_when: false
 
+    - name: list token roles empty
+      hashivault_token_role_list:
+      register: 'vault_role_list'
+    - assert: { that: "{{vault_role_list.changed}} == False" }
+    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - assert: { that: "{{vault_role_list.data|length}} == 0"}
+
     - name: create role
       hashivault_token_role:
         name: testrole
@@ -64,3 +71,10 @@
     - assert: { that: "{{vault_role_update.changed}} == False" }
     - assert: { that: "{{vault_role_update.rc}} == 0" }
 
+    - name: list token roles
+      hashivault_token_role_list:
+      register: 'vault_role_list'
+    - assert: { that: "{{vault_role_list.changed}} == False" }
+    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - fail: msg="role testrole not in list {{vault_role_list.data}}"
+      when: '"testrole" not in vault_role_list.data'

--- a/functional/test_token_role_check_mode.yml
+++ b/functional/test_token_role_check_mode.yml
@@ -43,3 +43,12 @@
       register: 'vault_role_create'
     - assert: { that: "{{vault_role_create.changed}} == False" }
     - assert: { that: "{{vault_role_create.rc}} == 0" }
+
+    - name: list token roles check_mode
+      hashivault_token_role_list:
+      register: 'vault_role_list'
+      check_mode: true
+    - assert: { that: "{{vault_role_list.changed}} == False" }
+    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - fail: msg="role testrole not in list {{vault_role_list.data}}"
+      when: '"testrole" not in vault_role_list.data'


### PR DESCRIPTION
This module lists roles configured in a specified token auth engine.

This module supports check mode (even though it does not perform any
write operations) to ensure a whole playbook can run in check mode and
proper data is still returned from this module for further tasks to use.

The code in this commit has been formatted with `black`.