### PR TITLE
Fixup idempotency of hashivault_auth_ldap

### DIFF
--- a/ansible/modules/hashivault/hashivault_auth_ldap.py
+++ b/ansible/modules/hashivault/hashivault_auth_ldap.py
@@ -139,8 +139,8 @@ def main():
     argspec['group_attr'] = dict(required=False, type='str', default='cn')
     argspec['group_dn'] = dict(required=False, type='str', default='')
     argspec['use_token_groups'] = dict(required=False, type='bool', default=False)
-    argspec['token_ttl'] = dict(required=False, type='str', default='')
-    argspec['token_max_ttl'] = dict(required=False, type='str', default='')
+    argspec['token_ttl'] = dict(required=False, type='int', default=0)
+    argspec['token_max_ttl'] = dict(required=False, type='int', default=0)
 
     module = hashivault_init(argspec, supports_check_mode=True)
     result = hashivault_auth_ldap(module)

--- a/functional/test_ldap_group.yml
+++ b/functional/test_ldap_group.yml
@@ -18,7 +18,7 @@
 
     - name: ldap configuration
       hashivault_auth_ldap:
-        ldap_url: ldap://127.0.0.1
+        ldap_url: ldap://localhost
       register: ldap_module
     - assert: { that: "{{ ldap_module.changed }} == True" }
     - assert: { that: "{{ ldap_module.rc }} == 0" }

--- a/functional/test_ldap_group.yml
+++ b/functional/test_ldap_group.yml
@@ -23,6 +23,12 @@
     - assert: { that: "{{ ldap_module.changed }} == True" }
     - assert: { that: "{{ ldap_module.rc }} == 0" }
 
+    - name: ldap configuration is idempotent
+      hashivault_auth_ldap:
+        ldap_url: ldap://localhost
+      register: ldap_module_idempotent
+    - assert: { that: "{{ ldap_module_idempotent.changed }} == False" }
+
     - name: remove ldap group
       hashivault_ldap_group:
         name: test


### PR DESCRIPTION
hashivault_auth_ldap always returns as changed because the desired state token_ttl/token_max_ttl are strings whereas in the current state they are ints.

Fixes this by correcting the type.
I believe this corrects #393

Unrelated silly questyon but I see that the module now requires Ansible >=4 and was wondering why that might be? It seems to work find on 2.9 
