### PR TITLE
Extract option normalisation to module_utils and reverse logic to allow for unknown options

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -7,6 +7,7 @@ from hvac.exceptions import InvalidPath
 
 normalize = {'list': list, 'str': str, 'dict': dict, 'bool': bool, 'int': int, 'duration': str}
 
+
 def hashivault_argspec():
     argument_spec = dict(
         url=dict(required=False, default=os.environ.get('VAULT_ADDR', ''), type='str'),
@@ -43,11 +44,14 @@ def hashivault_init(argument_spec, supports_check_mode=False, required_if=None, 
     return module
 
 
-def hashivault_normalize_from_doc(options, documentation):
+def hashivault_normalize_from_doc(module, options, documentation):
     desired_state = {}
     for key, value in options.items():
         config_type = documentation.get(key, {}).get('type')
-        if config_type is not None:
+        if config_type is None:
+            module.warn('Unknown option "{}". Make sure this is not a typo, if it is not, please open an '
+                        'issue at https://github.com/TerryHowe/ansible-modules-hashivault/issues.'.format(key))
+        else:
             try:
                 value = normalize[config_type](value)
             except Exception:
@@ -57,6 +61,7 @@ def hashivault_normalize_from_doc(options, documentation):
         desired_state[key] = value
 
     return desired_state
+
 
 def get_ec2_iam_role():
     request = requests.get(url='http://169.254.169.254/latest/meta-data/iam/security-credentials/')

--- a/ansible/modules/hashivault/hashivault_pki_role.py
+++ b/ansible/modules/hashivault/hashivault_pki_role.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
+from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init
-from ansible.module_utils.hashivault import is_state_changed
+from ansible.module_utils.hashivault import hashivault_normalize_from_doc
 from ansible.module_utils.hashivault import hashiwrapper
+from ansible.module_utils.hashivault import is_state_changed
 
 ANSIBLE_METADATA = {'status': ['preview'], 'supported_by': 'community', 'version': '1.1'}
 DOCUMENTATION = r'''
@@ -309,7 +310,6 @@ EXAMPLES = r'''
         role_file: "/opt/vault/etc/roles/pki-tester.json"
         state: "present"
 '''
-normalize = {'list': list, 'str': str, 'dict': dict, 'bool': bool, 'int': int, 'duration': str}
 
 
 def main():
@@ -351,15 +351,8 @@ def hashivault_pki_role(module):
     elif config:
         import yaml
         doc = yaml.safe_load(DOCUMENTATION)
-        args = doc.get('options').get('config').get('suboptions').items()
-        for key, value in args:
-            arg = config.get(key)
-            if arg is not None:
-                try:
-                    desired_state[key] = normalize[value.get('type')](arg)
-                except Exception:
-                    return {'changed': False, 'failed': True,
-                            'msg': 'config item \'{}\' has wrong data format'.format(key)}
+        args = doc.get('options').get('config').get('suboptions')
+        desired_state = hashivault_normalize_from_doc(config, args)
 
     changed = False
     try:

--- a/ansible/modules/hashivault/hashivault_pki_role.py
+++ b/ansible/modules/hashivault/hashivault_pki_role.py
@@ -352,7 +352,7 @@ def hashivault_pki_role(module):
         import yaml
         doc = yaml.safe_load(DOCUMENTATION)
         args = doc.get('options').get('config').get('suboptions')
-        desired_state = hashivault_normalize_from_doc(config, args)
+        desired_state = hashivault_normalize_from_doc(module, config, args)
 
     changed = False
     try:


### PR DESCRIPTION
This is a proposed mitigation to #426. Instead of copying known arguments to the desired_state, we copy all arguments, while normalizing the ones we know about.

I have extracted that function to module_utils because if that change is accepted, it's probably worth applying it to all modules. This is obviously just a stop gap measure, adding the new parameters is preferred, but seeing the low release frequency, this will avoid blocking users for a long time.

I can try and add some warning if the parameter is not found in the doc, that could help users identify typos and report missing fields.

WDYT?