### PR TITLE
Add timeout for all modules

### DIFF
--- a/ansible/module_utils/hashivault.py
+++ b/ansible/module_utils/hashivault.py
@@ -24,7 +24,8 @@ def hashivault_argspec():
         role_id=dict(required=False, fallback=(env_fallback, ['VAULT_ROLE_ID']), type='str', no_log=True),
         secret_id=dict(required=False, fallback=(env_fallback, ['VAULT_SECRET_ID']), type='str', no_log=True),
         aws_header=dict(required=False, fallback=(env_fallback, ['VAULT_AWS_HEADER']), type='str', no_log=True),
-        namespace=dict(required=False, default=os.environ.get('VAULT_NAMESPACE', None), type='str')
+        namespace=dict(required=False, default=os.environ.get('VAULT_NAMESPACE', None), type='str'),
+        timeout=dict(required=False, default=30, type=int)
     )
     return argument_spec
 
@@ -99,6 +100,7 @@ def hashivault_client(params):
     cert = (client_cert, client_key)
     check_verify = params.get('verify')
     namespace = params.get('namespace', None)
+    timeout = params.get('timeout')
     if check_verify == '' or check_verify:
         if ca_cert:
             verify = ca_cert
@@ -108,7 +110,7 @@ def hashivault_client(params):
             verify = check_verify
     else:
         verify = check_verify
-    client = hvac.Client(url=url, cert=cert, verify=verify, namespace=namespace)
+    client = hvac.Client(url=url, cert=cert, verify=verify, namespace=namespace, timeout=timeout)
     return client
 
 

--- a/ansible/plugins/doc_fragments/hashivault.py
+++ b/ansible/plugins/doc_fragments/hashivault.py
@@ -61,4 +61,8 @@ class ModuleDocFragment(object):
             description:
                 - namespace for vault
             default: to environment variable VAULT_NAMESPACE
+        timeout:
+            description:
+                - The timeout value (seconds) for requests sent to Vault.
+            default: 30
 '''


### PR DESCRIPTION
This would be useful. Default value of 30, [as it is in hvac](https://hvac.readthedocs.io/en/stable/source/hvac_v1.html#hvac.v1.Client.__init__), to prevent inconsistency. 