### PR TITLE
adding galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,12 @@
+---
+authors:
+  - Terry Howe
+license_file: LICENSE
+name: hashivault
+namespace: terryhowe
+description: Ansible Collection for Hashicorp Vault
+readme: README.md
+repository: https://github.com/TerryHowe/ansible-modules-hashivault
+issues: https://github.com/TerryHowe/ansible-modules-hashivault/issues
+tags: [vault]
+version: "5.1.2"

--- a/plugins/action
+++ b/plugins/action
@@ -1,0 +1,1 @@
+../ansible/plugins/action

--- a/plugins/lookup
+++ b/plugins/lookup
@@ -1,0 +1,1 @@
+../ansible/plugins/lookup

--- a/plugins/module_utils
+++ b/plugins/module_utils
@@ -1,0 +1,1 @@
+../ansible/module_utils

--- a/plugins/modules
+++ b/plugins/modules
@@ -1,0 +1,1 @@
+../ansible/modules/hashivault


### PR DESCRIPTION
Fixes installing this collection via a collection requirements yaml file. 

For example, the existing repo doesn't seem to install:
```
❯ cat requirements-origin.yml
---
collections:
  - name: "git+https://github.com/TerryHowe/ansible-modules-hashivault.git"
    version: 5.1.2

❯ ansible-galaxy install -r requirements-origin.yml
...
ERROR! Neither the collection requirement entry key 'name', nor 'source' point to a concrete resolvable collection artifact. Also 'name' is not an FQCN. A valid collection name must be in the format <namespace>.<collection>. Please make sure that the namespace and the collection name contain characters from [a-zA-Z0-9_] only.
```

When this file is added, it seems to work fine:
```
❯ cat requirements-fork.yml
---
collections:
  # this contains the galaxy.yml
  - name: "git+https://github.com/gbolo/ansible-modules-hashivault.git"
    version: 5.1.2

❯ ansible-galaxy install -r requirements-fork.yml
...
terryhowe.hashivault:5.1.2 was installed successfully
```

