### PR TITLE
Depend on ansible-core instead of ansible

### DIFF
--- a/functional/test_approle.yml
+++ b/functional/test_approle.yml
@@ -16,14 +16,14 @@
         name: "approle_test_policy_original"
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: Set another approle policy
       hashivault_policy:
         name: "approle_test_policy"
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: enable approle authentication
       hashivault_auth_method:
@@ -44,17 +44,17 @@
           - approle_test_policy_original
         state: present
       register: 'vault_role_create_bound_cidrs'
-    - assert: { that: "{{vault_role_create_bound_cidrs.changed}} == True" }
-    - assert: { that: "{{vault_role_create_bound_cidrs.rc}} == 0" }
+    - assert: { that: "vault_role_create_bound_cidrs is changed" }
+    - assert: { that: "vault_role_create_bound_cidrs.rc == 0" }
 
     - name: get role with token_bound_cidrs and secret_id_bound_cidrs
       hashivault_approle_role_get:
         name: testrole_bound_cidrs
       register: 'vault_role_get_bound_cidrs'
-    - assert: { that: "{{vault_role_get_bound_cidrs.changed}} == False" }
-    - assert: { that: "{{vault_role_get_bound_cidrs.rc}} == 0" }
-    - assert: { that: "'{{vault_role_get_bound_cidrs.role.data.token_bound_cidrs[0]}}' == '127.0.0.1'" }
-    - assert: { that: "'{{vault_role_get_bound_cidrs.role.data.secret_id_bound_cidrs[0]}}' == '127.0.0.1/32'" }
+    - assert: { that: "vault_role_get_bound_cidrs is not changed" }
+    - assert: { that: "vault_role_get_bound_cidrs.rc == 0" }
+    - assert: { that: "vault_role_get_bound_cidrs.role.data.token_bound_cidrs[0] == '127.0.0.1'" }
+    - assert: { that: "vault_role_get_bound_cidrs.role.data.secret_id_bound_cidrs[0] == '127.0.0.1/32'" }
 
     - name: create role
       hashivault_approle_role:
@@ -63,8 +63,8 @@
           - approle_test_policy_original
         state: present
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: update role
       hashivault_approle_role:
@@ -73,8 +73,8 @@
           - approle_test_policy
         state: present
       register: 'vault_role_update'
-    - assert: { that: "{{vault_role_update.changed}} == True" }
-    - assert: { that: "{{vault_role_update.rc}} == 0" }
+    - assert: { that: "vault_role_update is changed" }
+    - assert: { that: "vault_role_update.rc == 0" }
 
     - name: update role idempotent
       hashivault_approle_role:
@@ -83,14 +83,14 @@
           - approle_test_policy
         state: present
       register: 'vault_role_update'
-    - assert: { that: "{{vault_role_update.changed}} == False" }
-    - assert: { that: "{{vault_role_update.rc}} == 0" }
+    - assert: { that: "vault_role_update is not changed" }
+    - assert: { that: "vault_role_update.rc == 0" }
 
     - name: list roles
       hashivault_approle_role_list:
       register: 'vault_role_list'
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
     - fail: msg="role testrole not in list {{vault_role_list.roles}}"
       when: '"testrole" not in vault_role_list.roles'
 
@@ -98,15 +98,15 @@
       hashivault_approle_role_get:
         name: testrole
       register: 'vault_role'
-    - assert: { that: "{{vault_role.changed}} == False" }
-    - assert: { that: "{{vault_role.rc}} == 0" }
+    - assert: { that: "vault_role is not changed" }
+    - assert: { that: "vault_role.rc == 0" }
 
     - name: get role id
       hashivault_approle_role_id:
         name: testrole
       register: 'vault_role_id'
-    - assert: { that: "{{vault_role_id.changed}} == False" }
-    - assert: { that: "{{vault_role_id.rc}} == 0" }
+    - assert: { that: "vault_role_id is not changed" }
+    - assert: { that: "vault_role_id.rc == 0" }
     - assert:
         that:
           - vault_role_id.id|default('') != ''
@@ -120,8 +120,8 @@
         name: testrole
         state: present
       register: 'vault_role_secret_create'
-    - assert: { that: "{{vault_role_secret_create.changed}} == True" }
-    - assert: { that: "{{vault_role_secret_create.rc}} == 0" }
+    - assert: { that: "vault_role_secret_create is changed" }
+    - assert: { that: "vault_role_secret_create.rc == 0" }
     - assert:
         that:
           - vault_role_secret_create.data.secret_id_accessor|default('') != ''
@@ -140,8 +140,8 @@
       hashivault_approle_role_secret_list:
         name: testrole
       register: 'vault_role_secret_list'
-    - assert: { that: "{{vault_role_secret_list.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_list.rc}} == 0" }
+    - assert: { that: "vault_role_secret_list is not changed" }
+    - assert: { that: "vault_role_secret_list.rc == 0" }
     - fail: msg="secret {{approle_secret_id_accessor}} not in list"
       when: approle_secret_id_accessor not in vault_role_secret_list.secrets
 
@@ -150,26 +150,26 @@
         name: testrole
         secret: "{{approle_secret_id}}"
       register: 'vault_role_secret_get'
-    - assert: { that: "{{vault_role_secret_get.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_get.rc}} == 0" }
-    - assert: { that: "'{{vault_role_secret_get.secret.secret_id_accessor}}' == '{{approle_secret_id_accessor}}'" }
+    - assert: { that: "vault_role_secret_get is not changed" }
+    - assert: { that: "vault_role_secret_get.rc == 0" }
+    - assert: { that: "vault_role_secret_get.secret.secret_id_accessor == approle_secret_id_accessor" }
 
     - name: get non existing secret
       hashivault_approle_role_secret_get:
         name: testrole
         secret: "1-2-3-4"
       register: 'vault_role_secret_get_not_existing'
-    - assert: { that: "'{{vault_role_secret_get_not_existing.status}}' == 'absent'" }
-    - assert: { that: "{{vault_role_secret_get_not_existing.rc}} == 0" }
+    - assert: { that: "vault_role_secret_get_not_existing.status == 'absent'" }
+    - assert: { that: "vault_role_secret_get_not_existing.rc == 0" }
 
     - name: get secret accessor
       hashivault_approle_role_secret_accessor_get:
         name: testrole
         accessor: "{{approle_secret_id_accessor}}"
       register: 'vault_role_secret_accessor_get'
-    - assert: { that: "{{vault_role_secret_accessor_get.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_accessor_get.rc}} == 0" }
-    - assert: { that: "'{{vault_role_secret_accessor_get.secret.secret_id_accessor}}' != ''" }
+    - assert: { that: "vault_role_secret_accessor_get is not changed" }
+    - assert: { that: "vault_role_secret_accessor_get.rc == 0" }
+    - assert: { that: "vault_role_secret_accessor_get.secret.secret_id_accessor != ''" }
 
     - name: create secret to delete
       hashivault_approle_role_secret:
@@ -187,14 +187,14 @@
         secret: "{{approle_secret_id}}"
         state: absent
       register: 'vault_role_secret_delete'
-    - assert: { that: "{{vault_role_secret_delete.changed}} == True" }
-    - assert: { that: "{{vault_role_secret_delete.rc}} == 0" }
+    - assert: { that: "vault_role_secret_delete is changed" }
+    - assert: { that: "vault_role_secret_delete.rc == 0" }
 
     - name: make sure secret is gone
       hashivault_approle_role_secret_list:
         name: testrole
       register: 'vault_role_secret_list'
-    - assert: { that: "{{vault_role_secret_list.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_list.rc}} == 0" }
+    - assert: { that: "vault_role_secret_list is not changed" }
+    - assert: { that: "vault_role_secret_list.rc == 0" }
     - fail: msg="secret {{approle_secret_id_accessor}} shoud not be in list"
       when: approle_secret_id_accessor in vault_role_secret_list.secrets

--- a/functional/test_approle_check_mode.yml
+++ b/functional/test_approle_check_mode.yml
@@ -10,8 +10,8 @@
         state: present
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == False" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is not changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: create role check_mode does not exist
       hashivault_approle_role:
@@ -21,8 +21,8 @@
         state: present
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: delete role check_mode exists
       hashivault_approle_role:
@@ -30,8 +30,8 @@
         state: absent
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: delete role check_mode does not exist
       hashivault_approle_role:
@@ -39,8 +39,8 @@
         state: absent
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == False" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is not changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: create secret for check_mode test
       hashivault_approle_role_secret:
@@ -59,8 +59,8 @@
         state: absent
       check_mode: true
       register: 'vault_role_secret_delete'
-    - assert: { that: "{{vault_role_secret_delete.changed}} == True" }
-    - assert: { that: "{{vault_role_secret_delete.rc}} == 0" }
+    - assert: { that: "vault_role_secret_delete is changed" }
+    - assert: { that: "vault_role_secret_delete.rc == 0" }
 
     - name: delete secret does not exist check_mode
       hashivault_approle_role_secret:
@@ -69,5 +69,5 @@
         state: absent
       check_mode: true
       register: 'vault_role_secret_delete'
-    - assert: { that: "{{vault_role_secret_delete.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_delete.rc}} == 0" }
+    - assert: { that: "vault_role_secret_delete is not changed" }
+    - assert: { that: "vault_role_secret_delete.rc == 0" }

--- a/functional/test_approle_mount_point.yml
+++ b/functional/test_approle_mount_point.yml
@@ -16,7 +16,7 @@
         name: lightning_policy
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: enable lightning approle authentication
       hashivault_auth_method:
@@ -37,15 +37,15 @@
         token_policies:
           - lightning_policy
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: list roles
       hashivault_approle_role_list:
         mount_point: lightning
       register: 'vault_role_list'
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
     - fail: msg="role bigspark not in list"
       when: '"bigspark" not in vault_role_list.roles'
 
@@ -54,16 +54,16 @@
         name: bigspark
         mount_point: lightning
       register: 'vault_role'
-    - assert: { that: "{{vault_role.changed}} == False" }
-    - assert: { that: "{{vault_role.rc}} == 0" }
+    - assert: { that: "vault_role is not changed" }
+    - assert: { that: "vault_role.rc == 0" }
 
     - name: get role id
       hashivault_approle_role_id:
         name: bigspark
         mount_point: lightning
       register: 'vault_role_id'
-    - assert: { that: "{{vault_role_id.changed}} == False" }
-    - assert: { that: "{{vault_role_id.rc}} == 0" }
+    - assert: { that: "vault_role_id is not changed" }
+    - assert: { that: "vault_role_id.rc == 0" }
     - assert:
         that:
           - vault_role_id.id|default('') != ''
@@ -78,8 +78,8 @@
         mount_point: lightning
         state: present
       register: 'vault_role_secret_create'
-    - assert: { that: "{{vault_role_secret_create.changed}} == True" }
-    - assert: { that: "{{vault_role_secret_create.rc}} == 0" }
+    - assert: { that: "vault_role_secret_create is changed" }
+    - assert: { that: "vault_role_secret_create.rc == 0" }
     - assert:
         that:
           - vault_role_secret_create.data.secret_id_accessor|default('') != ''
@@ -99,8 +99,8 @@
         name: bigspark
         mount_point: lightning
       register: 'vault_role_secret_list'
-    - assert: { that: "{{vault_role_secret_list.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_list.rc}} == 0" }
+    - assert: { that: "vault_role_secret_list is not changed" }
+    - assert: { that: "vault_role_secret_list.rc == 0" }
     - fail: msg="secret {{approle_secret_id_accessor}} not in list"
       when: approle_secret_id_accessor not in vault_role_secret_list.secrets
 
@@ -110,9 +110,9 @@
         mount_point: lightning
         secret: "{{approle_secret_id}}"
       register: 'vault_role_secret_get'
-    - assert: { that: "{{vault_role_secret_get.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_get.rc}} == 0" }
-    - assert: { that: "'{{vault_role_secret_get.secret.secret_id_accessor}}' == '{{approle_secret_id_accessor}}'" }
+    - assert: { that: "vault_role_secret_get is not changed" }
+    - assert: { that: "vault_role_secret_get.rc == 0" }
+    - assert: { that: "vault_role_secret_get.secret.secret_id_accessor == approle_secret_id_accessor" }
 
 # unsupported by docker image
     - name: get secret accessor
@@ -121,6 +121,6 @@
         mount_point: lightning
         accessor: "{{approle_secret_id_accessor}}"
       register: 'vault_role_secret_accessor_get'
-    - assert: { that: "{{vault_role_secret_accessor_get.changed}} == False" }
-    - assert: { that: "{{vault_role_secret_accessor_get.rc}} == 0" }
-    - assert: { that: "'{{vault_role_secret_accessor_get.secret.secret_id_accessor}}' != ''" }
+    - assert: { that: "vault_role_secret_accessor_get is not changed" }
+    - assert: { that: "vault_role_secret_accessor_get.rc == 0" }
+    - assert: { that: "vault_role_secret_accessor_get.secret.secret_id_accessor != ''" }

--- a/functional/test_audit.yml
+++ b/functional/test_audit.yml
@@ -22,8 +22,8 @@
         options:
           path: "/tmp/vault.log"
       register: audit_module
-    - assert: { that: "{{audit_module.changed}} == True" }
-    - assert: { that: "{{audit_module.rc}} == 0" }
+    - assert: { that: "audit_module is changed" }
+    - assert: { that: "audit_module.rc == 0" }
 
     - name: Create audit idempotent (Vault does not support update at the moment anyway)
       hashivault_audit:
@@ -31,8 +31,8 @@
         options:
           path: "/tmp/vault.log"
       register: audit_module
-    - assert: { that: "{{audit_module.changed}} == False" }
-    - assert: { that: "{{audit_module.rc}} == 0" }
+    - assert: { that: "audit_module is not changed" }
+    - assert: { that: "audit_module.rc == 0" }
 
     - name: Create audit path
       hashivault_audit:
@@ -41,8 +41,8 @@
         options:
           path: "/tmp/path_vault.log"
       register: audit_module
-    - assert: { that: "{{audit_module.changed}} == True" }
-    - assert: { that: "{{audit_module.rc}} == 0" }
+    - assert: { that: "audit_module is changed" }
+    - assert: { that: "audit_module.rc == 0" }
 
     - name: Create audit path again
       hashivault_audit:
@@ -51,16 +51,16 @@
         options:
           path: "/tmp/path_vault.log"
       register: audit_module
-    - assert: { that: "{{audit_module.changed}} == False" }
-    - assert: { that: "{{audit_module.rc}} == 0" }
+    - assert: { that: "audit_module is not changed" }
+    - assert: { that: "audit_module.rc == 0" }
 
     - name: Delete audit
       hashivault_audit:
         device_type: file
         state: absent
       register: audit_module
-    - assert: { that: "{{audit_module.changed}} == True" }
-    - assert: { that: "{{audit_module.rc}} == 0" }
+    - assert: { that: "audit_module is changed" }
+    - assert: { that: "audit_module.rc == 0" }
 
     - name: Delete audit path
       hashivault_audit:
@@ -68,13 +68,13 @@
         path: pathy
         state: absent
       register: audit_module
-    - assert: { that: "{{audit_module.changed}} == True" }
-    - assert: { that: "{{audit_module.rc}} == 0" }
+    - assert: { that: "audit_module is changed" }
+    - assert: { that: "audit_module.rc == 0" }
 
     - name: Delete audit idempotent
       hashivault_audit:
         device_type: file
         state: absent
       register: audit_module
-    - assert: { that: "{{audit_module.changed}} == False" }
-    - assert: { that: "{{audit_module.rc}} == 0" }
+    - assert: { that: "audit_module is not changed" }
+    - assert: { that: "audit_module.rc == 0" }

--- a/functional/test_auth.yml
+++ b/functional/test_auth.yml
@@ -12,32 +12,31 @@
         method_type: "userpass"
         description: "my userpass"
       register: 'vault_auth'
-    - assert: { that: "{{vault_auth.changed}} == True" }
-    - assert: { that: "{{vault_auth.created}} == True" }
-    - assert: { that: "{{vault_auth.failed}} == False" }
-    - assert: { that: "{{vault_auth.rc}} == 0" }
+    - assert: { that: "vault_auth is changed" }
+    - assert: { that: "vault_auth.created == True" }
+    - assert: { that: "vault_auth.failed == False" }
+    - assert: { that: "vault_auth.rc == 0" }
     - name: Enable userpass when it is already enabled
       hashivault_auth_method:
         method_type: "userpass"
         description: "my userpass"
       register: 'vault_auth'
-    - assert: { that: "{{vault_auth.changed}} == False" }
-    - assert: { that: "{{vault_auth.created}} == False" }
-    - assert: { that: "{{vault_auth.failed}} == False" }
-    - assert: { that: "{{vault_auth.rc}} == 0" }
+    - assert: { that: "vault_auth is not changed" }
+    - assert: { that: "vault_auth.created == False" }
+    - assert: { that: "vault_auth.failed == False" }
+    - assert: { that: "vault_auth.rc == 0" }
     - name: Enable userpass auth for the third time with change
       hashivault_auth_method:
         method_type: "userpass"
         description: "our userpass"
       register: 'vault_auth'
-    - assert: { that: "{{vault_auth.changed}} == True" }
-    - assert: { that: "{{vault_auth.created}} == False" }
-    - assert: { that: "{{vault_auth.rc}} == 0" }
+    - assert: { that: "vault_auth is changed" }
+    - assert: { that: "vault_auth.created == False" }
+    - assert: { that: "vault_auth.rc == 0" }
     - name: Enable userpass at a different mount point
       hashivault_auth_method:
         method_type: "userpass"
         mount_point: "another-userpass"
       register: 'vault_auth_mount_point'
-    - assert: { that: "{{vault_auth_mount_point.changed}} == True" }
-    - assert: { that: "{{vault_auth_mount_point.rc}} == 0" }
-        
+    - assert: { that: "vault_auth_mount_point is changed" }
+    - assert: { that: "vault_auth_mount_point.rc == 0" }

--- a/functional/test_auth_method.yml
+++ b/functional/test_auth_method.yml
@@ -15,20 +15,20 @@
         method_type: azure
         state: disabled
       register: disable_idem
-    - assert: { that: "{{ disable_idem.changed }} == False" }
+    - assert: { that: "disable_idem is not changed" }
 
     - name: enable azure secret engine
       hashivault_auth_method:
         method_type: azure
       register: enable_chg
-    - assert: { that: "{{ enable_chg.changed }} == True" }
+    - assert: { that: "enable_chg is changed" }
 
     - name: disable azure
       hashivault_auth_method:
         method_type: azure
         state: disabled
       register: disable_chg
-    - assert: { that: "{{ disable_chg.changed }} == True" }
+    - assert: { that: "disable_chg is changed" }
 
     - name: "Enable OIDC auth method"
       hashivault_auth_method:
@@ -38,8 +38,8 @@
           default_lease_ttl: 0
           max_lease_ttl: 0
       register: oidc_idempotent
-    - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
-    - assert: { that: "{{ oidc_idempotent.changed }} == True" }
+    - assert: { that: "oidc_idempotent.rc == 0" }
+    - assert: { that: "oidc_idempotent is changed" }
 
     - name: "Enable OIDC auth method idempotent"
       hashivault_auth_method:
@@ -49,8 +49,8 @@
           default_lease_ttl: 0
           max_lease_ttl: 0
       register: oidc_idempotent
-    - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
-    - assert: { that: "{{ oidc_idempotent.changed }} == False" }
+    - assert: { that: "oidc_idempotent.rc == 0" }
+    - assert: { that: "oidc_idempotent is not changed" }
 
     - name: "Enable OIDC auth method update"
       hashivault_auth_method:
@@ -61,8 +61,8 @@
           max_lease_ttl: 0
         description: 'my oidc'
       register: oidc_idempotent
-    - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
-    - assert: { that: "{{ oidc_idempotent.changed }} == True" }
+    - assert: { that: "oidc_idempotent.rc == 0" }
+    - assert: { that: "oidc_idempotent is changed" }
 
     - name: "Enable OIDC auth method update description idempotent"
       hashivault_auth_method:
@@ -73,8 +73,8 @@
           max_lease_ttl: 0
         description: 'my oidc'
       register: oidc_idempotent
-    - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
-    - assert: { that: "{{ oidc_idempotent.changed }} == False" }
+    - assert: { that: "oidc_idempotent.rc == 0" }
+    - assert: { that: "oidc_idempotent is not changed" }
 
     - name: "Enable OIDC auth method update"
       hashivault_auth_method:
@@ -83,8 +83,8 @@
         config:
           default_lease_ttl: 2764799
       register: oidc_idempotent
-    - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
-    - assert: { that: "{{ oidc_idempotent.changed }} == True" }
+    - assert: { that: "oidc_idempotent.rc == 0" }
+    - assert: { that: "oidc_idempotent is changed" }
 
     - name: "Enable OIDC auth method update idempotent"
       hashivault_auth_method:
@@ -93,5 +93,5 @@
         config:
           default_lease_ttl: 2764799
       register: oidc_idempotent
-    - assert: { that: "{{ oidc_idempotent.rc }} == 0" }
-    - assert: { that: "{{ oidc_idempotent.changed }} == False" }
+    - assert: { that: "oidc_idempotent.rc == 0" }
+    - assert: { that: "oidc_idempotent is not changed" }

--- a/functional/test_aws_auth_config.yml
+++ b/functional/test_aws_auth_config.yml
@@ -14,12 +14,12 @@
         access_key: bob
         secret_key: topsecret
       register: aws_result
-    - assert: { that: "{{aws_result.changed}} == True" }
-    - assert: { that: "{{aws_result.rc}} == 0" }
+    - assert: { that: "aws_result is changed" }
+    - assert: { that: "aws_result.rc == 0" }
 
     - hashivault_aws_auth_config:
         mount_point: aws
         state: absent
       register: aws_result
-    - assert: { that: "{{aws_result.changed}} == True" }
-    - assert: { that: "{{aws_result.rc}} == 0" }
+    - assert: { that: "aws_result is changed" }
+    - assert: { that: "aws_result.rc == 0" }

--- a/functional/test_aws_auth_role.yml
+++ b/functional/test_aws_auth_role.yml
@@ -16,12 +16,12 @@
         inferred_aws_region: eu-west-1
         bound_iam_role_arn: arn:aws:iam::12345678:role/ec2-role
       register: aws_result
-    - assert: { that: "{{aws_result.changed}} == True" }
-    - assert: { that: "{{aws_result.rc}} == 0" }
+    - assert: { that: "aws_result is changed" }
+    - assert: { that: "aws_result.rc == 0" }
 
     - hashivault_aws_auth_role:
         name: ec2-role
         state: absent
       register: aws_result
-    - assert: { that: "{{aws_result.changed}} == True" }
-    - assert: { that: "{{aws_result.rc}} == 0" }
+    - assert: { that: "aws_result is changed" }
+    - assert: { that: "aws_result.rc == 0" }

--- a/functional/test_azure_auth_config.yml
+++ b/functional/test_azure_auth_config.yml
@@ -11,7 +11,7 @@
         method_type: azure
         state: disabled
       failed_when: false
-         
+
     - name: make sure test fails when no mount exists
       hashivault_azure_auth_config:
         client_id: "{{ client_id }}"
@@ -20,12 +20,12 @@
       register: fail_config
       failed_when: false
 
-    - assert: { that: "{{ fail_config.changed }} == False" }
-    
-    - name: enable azure auth method 
+    - assert: { that: "fail_config is not changed" }
+
+    - name: enable azure auth method
       hashivault_auth_method:
         method_type: azure
-         
+
     - name: successfully configure method
       hashivault_azure_auth_config:
         client_id: "{{ client_id }}"
@@ -33,7 +33,7 @@
         tenant_id: "{{ tenant_id }}"
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: attempt 2nd config with same values
       hashivault_azure_auth_config:
@@ -41,8 +41,8 @@
         client_secret: "{{ client_secret }}"
         tenant_id: "{{ tenant_id }}"
       register: idem_config
-    
-    - assert: { that: "{{ idem_config.changed }} == False" }
+
+    - assert: { that: "idem_config is not changed" }
 
     - name: attempt 3rd config with different values
       hashivault_azure_auth_config:
@@ -50,5 +50,5 @@
         client_secret: mlergh
         tenant_id: splurgh
       register: overwrite_config
-    
-    - assert: { that: "{{ overwrite_config.changed }} == True" }
+
+    - assert: { that: "overwrite_config is changed" }

--- a/functional/test_azure_auth_role.yml
+++ b/functional/test_azure_auth_role.yml
@@ -11,11 +11,11 @@
         method_type: azure
         state: disabled
       failed_when: false
-         
+
     - name: enable azure secret engine
       hashivault_auth_method:
         method_type: azure
-         
+
     - name: successfully configure mount
       hashivault_azure_auth_config:
         client_id: "{{ client_id }}"
@@ -29,8 +29,8 @@
         bound_subscription_ids: ["6a1d5988-5917-4221-b224-904cd7e24a25"]
         num_uses: 3
       register: success_config
-    
-    - assert: { that: "{{ success_config.changed }} == True" }
+
+    - assert: { that: "success_config is changed" }
 
     - name: idempotently create role
       hashivault_azure_auth_role:
@@ -39,13 +39,13 @@
         bound_subscription_ids: ["6a1d5988-5917-4221-b224-904cd7e24a25"]
         num_uses: 3
       register: idem_config
-    
-    - assert: { that: "{{ idem_config.changed }} == False" }
+
+    - assert: { that: "idem_config is not changed" }
 
     - name: delete role
       hashivault_azure_auth_role:
         name: test
         state: absent
       register: del_config
-    
-    - assert: { that: "{{ del_config.changed }} == True" }
+
+    - assert: { that: "del_config is changed" }

--- a/functional/test_azure_config.yml
+++ b/functional/test_azure_config.yml
@@ -22,7 +22,7 @@
       register: fail_config
       failed_when: false
 
-    - assert: { that: "{{ fail_config.changed }} == False" }
+    - assert: { that: "fail_config is not changed" }
 
     - hashivault_secret_engine:
         name: azure
@@ -37,7 +37,7 @@
         tenant_id: "{{ tenant_id }}"
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: attempt 2nd config with same values
       hashivault_azure_secret_engine_config:
@@ -47,7 +47,7 @@
         tenant_id: "{{ tenant_id }}"
       register: idem_config
 
-    - assert: { that: "{{ idem_config.changed }} == False" }
+    - assert: { that: "idem_config is not changed" }
 
     - name: attempt 3rd config with different values
       hashivault_azure_secret_engine_config:
@@ -57,4 +57,4 @@
         tenant_id: splurgh
       register: overwrite_config
 
-    - assert: { that: "{{ overwrite_config.changed }} == True" }
+    - assert: { that: "overwrite_config is changed" }

--- a/functional/test_azure_role.yml
+++ b/functional/test_azure_role.yml
@@ -22,13 +22,13 @@
       failed_when: false
       register: fail_config
 
-    - assert: { that: "{{ fail_config.changed }} == False" } # fail
-    
+    - assert: { that: "fail_config is not changed" } # fail
+
     - name: enable azure secret engine
       hashivault_secret_engine:
         name: azure
         backend: azure
-         
+
     - name: configure azure mount
       hashivault_azure_secret_engine_config:
         subscription_id: "{{ subscription_id }}"
@@ -42,7 +42,7 @@
         azure_role: "{{ azure_role1 }}"
       register: success_write
 
-    - assert: { that: "{{ success_write.changed }} == True" } # changed
+    - assert: { that: "success_write is changed" } # changed
 
     - name: idem same azure_role
       hashivault_azure_secret_engine_role:
@@ -50,7 +50,7 @@
         azure_role: "{{ azure_role1 }}"
       register: idem_write
 
-    - assert: { that: "{{ idem_write.changed }} == False" } # not changed    
+    - assert: { that: "idem_write is not changed" } # not changed
 
     - name: overwrite existing
       hashivault_azure_secret_engine_role:
@@ -58,7 +58,7 @@
         azure_role: "{{ azure_role2 }}"
       register: overwrite
 
-    - assert: { that: "{{ overwrite.changed }} == True" } # changed
+    - assert: { that: "overwrite is changed" } # changed
 
     # since we're doing dict compare, ensure that a dict with less obj
     # correctly is overwritten
@@ -68,4 +68,4 @@
         azure_role: "{{ azure_role1 }}"
       register: overwrite_smaller
 
-    - assert: { that: "{{ overwrite_smaller.changed }} == True" } # changed
+    - assert: { that: "overwrite_smaller is changed" } # changed

--- a/functional/test_cas.yml
+++ b/functional/test_cas.yml
@@ -16,8 +16,8 @@
           version: 2
         cas_required: True
       register: 'vault_secret_enable'
-    - assert: { that: "{{vault_secret_enable.changed}} == True" }
-    - assert: { that: "{{vault_secret_enable.rc}} == 0" }
+    - assert: { that: "vault_secret_enable is changed" }
+    - assert: { that: "vault_secret_enable.rc == 0" }
 
     - name: Update kv2 secret store engine
       hashivault_secret_engine:
@@ -27,8 +27,8 @@
           version: 2
         max_versions: 8
       register: 'vault_secret_enable'
-    - assert: { that: "{{vault_secret_enable.changed}} == True" }
-    - assert: { that: "{{vault_secret_enable.rc}} == 0" }
+    - assert: { that: "vault_secret_enable is changed" }
+    - assert: { that: "vault_secret_enable.rc == 0" }
 
     - name: Update kv2 secret store engine idempotent
       hashivault_secret_engine:
@@ -39,8 +39,8 @@
         cas_required: True
         max_versions: 8
       register: 'vault_secret_enable'
-    - assert: { that: "{{vault_secret_enable.changed}} == False" }
-    - assert: { that: "{{vault_secret_enable.rc}} == 0" }
+    - assert: { that: "vault_secret_enable is not changed" }
+    - assert: { that: "vault_secret_enable.rc == 0" }
 
     - name: cas kv2 write
       hashivault_write:
@@ -51,9 +51,9 @@
         data:
             value: firstvalue
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret kv2/casy written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret kv2/casy written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: cas kv2 write two
       hashivault_write:
@@ -64,9 +64,9 @@
         data:
             value: secondvalue
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret kv2/casy written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret kv2/casy written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: cas kv2 write fail
       hashivault_write:
@@ -78,9 +78,9 @@
             value: firstvalue
       failed_when: False
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "'did not match the current version' in '{{vault_write.msg}}'" }
-    - assert: { that: "{{vault_write.rc}} == 1" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "'did not match the current version' in vault_write.msg" }
+    - assert: { that: "vault_write.rc == 1" }
 
 
     - name: no cas kv2 write fail
@@ -92,14 +92,14 @@
             value: firstvalue
       failed_when: False
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "'check-and-set parameter required' in '{{vault_write.msg}}'" }
-    - assert: { that: "{{vault_write.rc}} == 1" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "'check-and-set parameter required' in vault_write.msg" }
+    - assert: { that: "vault_write.rc == 1" }
 
     - name: Disable kv2 secret store
       hashivault_secret_engine:
         name: "kv2"
         state: absent
       register: 'vault_secret_disable'
-    - assert: { that: "{{vault_secret_disable.changed}} == True" }
-    - assert: { that: "{{vault_secret_disable.rc}} == 0" }
+    - assert: { that: "vault_secret_disable is changed" }
+    - assert: { that: "vault_secret_disable.rc == 0" }

--- a/functional/test_consul_config.yml
+++ b/functional/test_consul_config.yml
@@ -19,8 +19,8 @@
         consul_token: "{{ consul_token }}"
       register: fail_config
       failed_when: false
-    - assert: { that: "{{ fail_config.changed }} == False" }
-    - assert: { that: "{{ fail_config.rc }} == 1" }
+    - assert: { that: "fail_config is not changed" }
+    - assert: { that: "fail_config.rc == 1" }
 
     - name: enable database secret engine
       hashivault_secret_engine:
@@ -33,5 +33,5 @@
         scheme: "{{ scheme }}"
         consul_token: "{{ consul_token }}"
       register: success_config
-    - assert: { that: "{{ success_config.changed }} == True" }
-    - assert: { that: "{{ success_config.rc }} == 0" }
+    - assert: { that: "success_config is changed" }
+    - assert: { that: "success_config.rc == 0" }

--- a/functional/test_consul_role.yml
+++ b/functional/test_consul_role.yml
@@ -26,24 +26,24 @@
         name: "{{ role_name }}"
       register: fail_write
       failed_when: false
-    - assert: { that: "{{ fail_write.rc }} == 1" }
-    - assert: { that: "{{ fail_write.changed }} == False" }
+    - assert: { that: "fail_write.rc == 1" }
+    - assert: { that: "fail_write is not changed" }
 
     - name: successfully write a role
       hashivault_consul_secret_engine_role:
         name: "{{ role_name }}"
         policy: "{{ policy }}"
       register: success_write
-    - assert: { that: "{{ success_write.rc }} == 0" }
-    - assert: { that: "{{ success_write.changed }} == True" }
+    - assert: { that: "success_write.rc == 0" }
+    - assert: { that: "success_write is changed" }
 
     - name: idempotent write a role
       hashivault_consul_secret_engine_role:
         name: "{{ role_name }}"
         policy: "{{ policy }}"
       register: idem_write
-    - assert: { that: "{{ idem_write.rc }} == 0" }
-    - assert: { that: "{{ idem_write.changed }} == False" }
+    - assert: { that: "idem_write.rc == 0" }
+    - assert: { that: "idem_write is not changed" }
 
     - name: successfully update a role
       hashivault_consul_secret_engine_role:
@@ -51,21 +51,21 @@
         policy: "{{ policy }}"
         max_ttl: 12345
       register: success_write
-    - assert: { that: "{{ success_write.rc }} == 0" }
-    - assert: { that: "{{ success_write.changed }} == True" }
+    - assert: { that: "success_write.rc == 0" }
+    - assert: { that: "success_write is changed" }
 
     - name: delete role
       hashivault_consul_secret_engine_role:
         name: "{{ role_name }}"
         state: absent
       register: success_del
-    - assert: { that: "{{ success_del.rc }} == 0" }
-    - assert: { that: "{{ success_del.changed }} == True" }
+    - assert: { that: "success_del.rc == 0" }
+    - assert: { that: "success_del is changed" }
 
     - name: idempotent delete role
       hashivault_consul_secret_engine_role:
         name: "{{ role_name }}"
         state: absent
       register: success_del
-    - assert: { that: "{{ success_del.rc }} == 0" }
-    - assert: { that: "{{ success_del.changed }} == False" }
+    - assert: { that: "success_del.rc == 0" }
+    - assert: { that: "success_del is not changed" }

--- a/functional/test_db_config.yml
+++ b/functional/test_db_config.yml
@@ -15,7 +15,7 @@
       hashivault_secret_engine:
         name: database
         state: disable
-         
+
     - name: make sure test fails when no mount exists
       hashivault_db_secret_engine_config:
         name: test
@@ -28,13 +28,13 @@
       register: fail_config
       failed_when: false
 
-    - assert: { that: "{{ fail_config.changed }} == False" }
-    
+    - assert: { that: "fail_config is not changed" }
+
     - name: enable database secret engine
       hashivault_secret_engine:
         name: database
         backend: database
-         
+
     - name: successfully configure
       hashivault_db_secret_engine_config:
         name: test
@@ -46,7 +46,7 @@
           connection_url: "{{ connection_url }}"
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: skip 2nd config attempt with same values
       hashivault_db_secret_engine_config:
@@ -58,8 +58,8 @@
           password: "{{ db_password }}"
           connection_url: "{{ connection_url }}"
       register: idem_config
-    
-    - assert: { that: "{{ idem_config.changed }} == False" }
+
+    - assert: { that: "idem_config is not changed" }
 
     - name: attempt 3rd config with different values
       hashivault_db_secret_engine_config:
@@ -71,5 +71,5 @@
           password: "{{ db_password }}"
           connection_url: "{{ connection_url }}"
       register: overwrite_config
-    
-    - assert: { that: "{{ overwrite_config.changed }} == True" }
+
+    - assert: { that: "overwrite_config is changed" }

--- a/functional/test_db_role.yml
+++ b/functional/test_db_role.yml
@@ -14,7 +14,7 @@
       hashivault_secret_engine:
         name: database
         state: disable
-         
+
     - name: make sure test fails when no mount exists
       hashivault_db_secret_engine_config:
         name: test
@@ -26,13 +26,13 @@
       register: fail_config
       failed_when: false
 
-    - assert: { that: "{{ fail_config.changed }} == False" }
-    
+    - assert: { that: "fail_config is not changed" }
+
     - name: enable database secret engine
       hashivault_secret_engine:
         name: database
         backend: database
-         
+
     - name: successfully configure
       hashivault_db_secret_engine_config:
         name: test
@@ -43,7 +43,7 @@
         connection_url: "{{ connection_url }}"
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: successfully write a role
       hashivault_db_secret_engine_role:
@@ -51,8 +51,8 @@
         db_name: test
         creation_statements: []
       register: success_write
-    
-    - assert: { that: "{{ success_write.changed }} == True" }
+
+    - assert: { that: "success_write is changed" }
 
     - name: skip write a role
       hashivault_db_secret_engine_role:
@@ -60,8 +60,8 @@
         db_name: test
         creation_statements: []
       register: idem_write
-    
-    - assert: { that: "{{ idem_write.changed }} == False" }
+
+    - assert: { that: "idem_write is not changed" }
 
     - name: delete role
       hashivault_db_secret_engine_role:
@@ -69,8 +69,8 @@
         db_name: test
         state: absent
       register: success_del
-    
-    - assert: { that: "{{ success_del.changed }} == True" }
+
+    - assert: { that: "success_del is changed" }
 
     - name: skip delete role
       hashivault_db_secret_engine_role:
@@ -78,5 +78,5 @@
         db_name: test
         state: absent
       register: success_del
-    
-    - assert: { that: "{{ success_del.changed }} == False" }
+
+    - assert: { that: "success_del is not changed" }

--- a/functional/test_delete.yml
+++ b/functional/test_delete.yml
@@ -16,14 +16,14 @@
       hashivault_delete:
         secret: test_delete
       register: vault_delete
-    - assert: { that: "{{vault_delete.changed}} == True" }
-    - assert: { that: "{{vault_delete.rc}} == 0" }
-    - assert: { that: "'{{vault_delete.msg}}' == 'Secret secret/test_delete deleted'" }
+    - assert: { that: "vault_delete is changed" }
+    - assert: { that: "vault_delete.rc == 0" }
+    - assert: { that: "vault_delete.msg == 'Secret secret/test_delete deleted'" }
 
     - name: Make sure secret value is gone
       hashivault_read:
         secret: test_delete
       register: vault_read
       failed_when: False
-    - assert: { that: "{{vault_read.changed}} == False" }
-    - assert: { that: "'{{vault_read.msg}}' == 'Secret secret/test_delete is not in vault'" }
+    - assert: { that: "vault_read is not changed" }
+    - assert: { that: "vault_read.msg == 'Secret secret/test_delete is not in vault'" }

--- a/functional/test_delete_permanent.yml
+++ b/functional/test_delete_permanent.yml
@@ -17,14 +17,14 @@
         secret: test_delete_permanent
         permanent: true
       register: vault_delete
-    - assert: { that: "{{vault_delete.changed}} == True" }
-    - assert: { that: "{{vault_delete.rc}} == 0" }
-    - assert: { that: "'{{vault_delete.msg}}' == 'Secret secret/test_delete_permanent deleted'" }
+    - assert: { that: "vault_delete is changed" }
+    - assert: { that: "vault_delete.rc == 0" }
+    - assert: { that: "vault_delete.msg == 'Secret secret/test_delete_permanent deleted'" }
 
     - name: Make sure secret value is gone
       hashivault_read:
         secret: test_delete_permanent
       register: vault_read
       failed_when: False
-    - assert: { that: "{{vault_read.changed}} == False" }
-    - assert: { that: "'{{vault_read.msg}}' == 'Secret secret/test_delete_permanent is not in vault'" }
+    - assert: { that: "vault_read is not changed" }
+    - assert: { that: "vault_read.msg == 'Secret secret/test_delete_permanent is not in vault'" }

--- a/functional/test_environment_lookup.yml
+++ b/functional/test_environment_lookup.yml
@@ -1,4 +1,4 @@
-#   
+#
 # This test depends on successful test_write run
 #
 ---
@@ -24,4 +24,4 @@
   tasks:
     - set_fact:
         a_set_fie: "{{lookup('hashivault', '{{name_root}}', 'fie')}}"
-    - assert: { that: "'{{a_set_fie}}' == 'fum'" }
+    - assert: { that: "a_set_fie == 'fum'" }

--- a/functional/test_ephemeral.yml
+++ b/functional/test_ephemeral.yml
@@ -12,16 +12,16 @@
         name: "ephemeral"
         backend: "generic"
       register: 'vault_secret_enable'
-    - assert: { that: "{{vault_secret_enable.changed}} == True" }
-    - assert: { that: "{{vault_secret_enable.rc}} == 0" }
+    - assert: { that: "vault_secret_enable is changed" }
+    - assert: { that: "vault_secret_enable.rc == 0" }
 
     - name: Enable same secret store again and check it doesn't fail
       hashivault_secret_engine:
         name: "ephemeral"
         backend: "generic"
       register: 'vault_secret_enable_twice'
-    - assert: { that: "{{vault_secret_enable_twice.changed}} == False" }
-    - assert: { that: "{{vault_secret_enable_twice.rc}} == 0" }
+    - assert: { that: "vault_secret_enable_twice is not changed" }
+    - assert: { that: "vault_secret_enable_twice.rc == 0" }
 
     - name: Write a value to the ephemeral store
       hashivault_write:
@@ -34,27 +34,27 @@
         secret: '/ephemeral/name'
         key: 'value'
       register: 'vault_read'
-    - assert: { that: "'{{vault_read.value}}' == 'ephemeral_stuff'" }
+    - assert: { that: "vault_read.value == 'ephemeral_stuff'" }
 
     - set_fact:
         looky_ephemeral: "{{lookup('hashivault', '/ephemeral/name', 'value')}}"
-    - assert: { that: "'{{looky_ephemeral}}' == 'ephemeral_stuff'" }
+    - assert: { that: "looky_ephemeral == 'ephemeral_stuff'" }
 
     - name: Delete ephemeral secret
       hashivault_delete:
         secret: '/ephemeral/name'
       register: 'vault_secret_eph_delete'
-    - assert: { that: "{{vault_secret_eph_delete.changed}} == True" }
-    - assert: { that: "{{vault_secret_eph_delete.rc}} == 0" }
-    - assert: { that: "'{{vault_secret_eph_delete.msg}}' == 'Secret ephemeral/name deleted'" }
+    - assert: { that: "vault_secret_eph_delete is changed" }
+    - assert: { that: "vault_secret_eph_delete.rc == 0" }
+    - assert: { that: "vault_secret_eph_delete.msg == 'Secret ephemeral/name deleted'" }
 
     - name: Make sure ephemeral value is gone
       hashivault_read:
         secret: '/ephemeral/name'
       register: 'vault_read'
       failed_when: False
-    - assert: { that: "{{vault_read.changed}} == False" }
-    - assert: { that: "'{{vault_read.msg}}' == 'Secret ephemeral/name is not in vault'" }
+    - assert: { that: "vault_read is not changed" }
+    - assert: { that: "vault_read.msg == 'Secret ephemeral/name is not in vault'" }
 
     - name: Tune ephemeral secret store
       hashivault_secret_engine:
@@ -62,8 +62,8 @@
         backend: "generic"
         description: "new description"
       register: vault_update
-    - assert: { that: "{{ vault_update.changed }} == True" }
-    - assert: { that: "{{ vault_update.rc }} == 0" }
+    - assert: { that: "vault_update is changed" }
+    - assert: { that: "vault_update.rc == 0" }
 
     - name: Idempotent tuning ephemeral secret store
       hashivault_secret_engine:
@@ -71,13 +71,13 @@
         backend: "generic"
         description: "new description"
       register: vault_update
-    - assert: { that: "{{ vault_update.changed }} == False" }
-    - assert: { that: "{{ vault_update.rc }} == 0" }
+    - assert: { that: "vault_update is not changed" }
+    - assert: { that: "vault_update.rc == 0" }
 
     - name: Disable ephemeral secret store
       hashivault_secret_engine:
         name: "ephemeral"
         state: disabled
       register: 'vault_secret_disable'
-    - assert: { that: "{{vault_secret_enable.changed}} == True" }
-    - assert: { that: "{{vault_secret_enable.rc}} == 0" }
+    - assert: { that: "vault_secret_enable is changed" }
+    - assert: { that: "vault_secret_enable.rc == 0" }

--- a/functional/test_full_path.yml
+++ b/functional/test_full_path.yml
@@ -13,25 +13,25 @@
         data:
           basket: ball
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/full/path written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret secret/full/path written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Read full path
       hashivault_read:
         secret: /secret/full/path
         key: basket
       register: vault_read
-    - assert: { that: "'{{vault_read.value}}' == 'ball'" }
+    - assert: { that: "vault_read.value == 'ball'" }
 
     - set_fact:
         basket: "{{lookup('hashivault', '/secret/full/path', 'basket')}}"
-    - assert: { that: "'{{basket}}' == 'ball'" }
+    - assert: { that: "basket == 'ball'" }
 
     - name: Delete full path
       hashivault_delete:
         secret: /secret/full/path
       register: vault_delete
-    - assert: { that: "{{vault_delete.changed}} == True" }
-    - assert: { that: "{{vault_delete.rc}} == 0" }
-    - assert: { that: "'{{vault_delete.msg}}' == 'Secret secret/full/path deleted'" }
+    - assert: { that: "vault_delete is changed" }
+    - assert: { that: "vault_delete.rc == 0" }
+    - assert: { that: "vault_delete.msg == 'Secret secret/full/path deleted'" }

--- a/functional/test_generate_root.yml
+++ b/functional/test_generate_root.yml
@@ -5,57 +5,57 @@
     vault_keys:  "{{ lookup('env','VAULT_KEYS') }}"
   tasks:
     - assert:
-        that: "'{{vault_keys}}' != ''"
+        that: "vault_keys != ''"
         msg: "VAULT_KEYS must be set to run this test"
 
     - name: Cancel anything that might be going
       hashivault_generate_root_cancel:
       register: hashivault_generate_root_cancel
-    - assert: { that: "{{hashivault_generate_root_cancel.rc}} == 0" }
+    - assert: { that: "hashivault_generate_root_cancel.rc == 0" }
 
     - name: Generate root token initialize
       hashivault_generate_root_init:
       register: hashivault_generate_root_init
-    - assert: { that: "{{hashivault_generate_root_init.changed}} == True" }
-    - assert: { that: "{{hashivault_generate_root_init.rc}} == 0" }
+    - assert: { that: "hashivault_generate_root_init is changed" }
+    - assert: { that: "hashivault_generate_root_init.rc == 0" }
 
     - name: Generate root status
       hashivault_generate_root_status:
       register: hashivault_generate_root_status
-    - assert: { that: "{{hashivault_generate_root_status.changed}} == False" }
-    - assert: { that: "{{hashivault_generate_root_status.rc}} == 0" }
+    - assert: { that: "hashivault_generate_root_status is not changed" }
+    - assert: { that: "hashivault_generate_root_status.rc == 0" }
 
     - name: Generate a root token
       hashivault_generate_root:
         key: "{{vault_keys}}"
         nonce: "{{hashivault_generate_root_init.status.nonce}}"
       register: hashivault_generate_root
-    - assert: { that: "{{hashivault_generate_root.changed}} == True" }
-    - assert: { that: "{{hashivault_generate_root.rc}} == 0" }
-    - assert: { that: "{{hashivault_generate_root.status.complete}} == True" }
+    - assert: { that: "hashivault_generate_root is changed" }
+    - assert: { that: "hashivault_generate_root.rc == 0" }
+    - assert: { that: "hashivault_generate_root.status.complete == True" }
 
     - name: Generate root token initialize
       hashivault_generate_root_init:
       register: hashivault_generate_root_init
-    - assert: { that: "{{hashivault_generate_root_init.changed}} == True" }
-    - assert: { that: "{{hashivault_generate_root_init.rc}} == 0" }
+    - assert: { that: "hashivault_generate_root_init is changed" }
+    - assert: { that: "hashivault_generate_root_init.rc == 0" }
 
     - name: Generate root status
       hashivault_generate_root_status:
       register: hashivault_generate_root_status
-    - assert: { that: "{{hashivault_generate_root_status.changed}} == False" }
-    - assert: { that: "{{hashivault_generate_root_status.rc}} == 0" }
-    - assert: { that: "{{hashivault_generate_root_status.status.started}} == True" }
+    - assert: { that: "hashivault_generate_root_status is not changed" }
+    - assert: { that: "hashivault_generate_root_status.rc == 0" }
+    - assert: { that: "hashivault_generate_root_status.status.started == True" }
 
     - name: Cancel that
       hashivault_generate_root_cancel:
       register: hashivault_generate_root_cancel
-    - assert: { that: "{{hashivault_generate_root_cancel.changed}} == True" }
-    - assert: { that: "{{hashivault_generate_root_cancel.rc}} == 0" }
+    - assert: { that: "hashivault_generate_root_cancel is changed" }
+    - assert: { that: "hashivault_generate_root_cancel.rc == 0" }
 
     - name: Generate root status
       hashivault_generate_root_status:
       register: hashivault_generate_root_status
-    - assert: { that: "{{hashivault_generate_root_status.changed}} == False" }
-    - assert: { that: "{{hashivault_generate_root_status.rc}} == 0" }
-    - assert: { that: "{{hashivault_generate_root_status.status.started}} == False" }
+    - assert: { that: "hashivault_generate_root_status is not changed" }
+    - assert: { that: "hashivault_generate_root_status.rc == 0" }
+    - assert: { that: "hashivault_generate_root_status.status.started == False" }

--- a/functional/test_identity_entity.yml
+++ b/functional/test_identity_entity.yml
@@ -14,32 +14,32 @@
         name: bob
         policies: bob
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == True" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - name: Update no change
       hashivault_identity_entity:
         name: bob
         policies: bob
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == False" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is not changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - name: Update remove policy
       hashivault_identity_entity:
         name: bob
         policies: null
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == False" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is not changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - name: Update readd policy
       hashivault_identity_entity:
         name: bob
         policies: bob
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == False" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is not changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - name: Update
       hashivault_identity_entity:
@@ -50,43 +50,43 @@
           c: d
         disabled: True
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == True" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - name: Delete it for the first time
       hashivault_identity_entity:
         name: bob
         state: absent
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == True" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - name: Delete it again
       hashivault_identity_entity:
         name: bob
         state: absent
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == False" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is not changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - name: Create new one
       hashivault_identity_entity:
         name: sam
         policies: sam
       register: vault_identity
-    - assert: { that: "{{vault_identity.changed}} == True" }
-    - assert: { that: "{{vault_identity.rc}} == 0" }
+    - assert: { that: "vault_identity is changed" }
+    - assert: { that: "vault_identity.rc == 0" }
 
     - hashivault_identity_entity_alias:
         name: sammy
         entity_name: sam
       register: vault_identity_alias
-    - assert: { that: "{{vault_identity_alias.changed}} == True" }
-    - assert: { that: "{{vault_identity_alias.rc}} == 0" }
+    - assert: { that: "vault_identity_alias is changed" }
+    - assert: { that: "vault_identity_alias.rc == 0" }
     - hashivault_identity_entity_alias:
         name: sammy
         entity_name: sam
         state: absent
       register: vault_identity_alias
-    - assert: { that: "{{vault_identity_alias.changed}} == True" }
-    - assert: { that: "{{vault_identity_alias.rc}} == 0" }
+    - assert: { that: "vault_identity_alias is changed" }
+    - assert: { that: "vault_identity_alias.rc == 0" }

--- a/functional/test_identity_group.yml
+++ b/functional/test_identity_group.yml
@@ -23,7 +23,7 @@
         state: present
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: chg metadata
       hashivault_identity_group:
@@ -33,7 +33,7 @@
           functional: testing
       register: chg_metadata
 
-    - assert: { that: "{{ chg_metadata.changed }} == True" }
+    - assert: { that: "chg_metadata is changed" }
 
     - name: duplicate metadata
       hashivault_identity_group:
@@ -43,7 +43,7 @@
           functional: testing
       register: chg_metadata
 
-    - assert: { that: "{{ chg_metadata.changed }} == False" }
+    - assert: { that: "chg_metadata is not changed" }
 
     - name: chg policies - add functional_testing_policy_one
       hashivault_identity_group:
@@ -53,7 +53,7 @@
           - functional_testing_policy_one
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == True" }
+    - assert: { that: "chg_policies is changed" }
 
     - name: duplicate policies
       hashivault_identity_group:
@@ -63,7 +63,7 @@
           - functional_testing_policy_one
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == False" }
+    - assert: { that: "chg_policies is not changed" }
 
     - name: chg policies - add functional_testing_policy_two
       hashivault_identity_group:
@@ -74,7 +74,7 @@
           - functional_testing_policy_two
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == True" }
+    - assert: { that: "chg_policies is changed" }
 
     - name: chg policies - remove functional_testing_policy_one
       hashivault_identity_group:
@@ -84,27 +84,27 @@
           - functional_testing_policy_two
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == True" }
+    - assert: { that: "chg_policies is changed" }
 
     - name: add external identity group
       hashivault_identity_group:
         name: extest
         group_type: external
       register: vault_identity_group
-    - assert: { that: "{{vault_identity_group.changed}} == True" }
-    - assert: { that: "{{vault_identity_group.rc}} == 0" }
+    - assert: { that: "vault_identity_group is changed" }
+    - assert: { that: "vault_identity_group.rc == 0" }
 
     - hashivault_identity_group_alias:
         name: "extest alias"
         group_name: extest
       register: vault_identity_alias
-    - assert: { that: "{{vault_identity_alias.changed}} == True" }
-    - assert: { that: "{{vault_identity_alias.rc}} == 0" }
+    - assert: { that: "vault_identity_alias is changed" }
+    - assert: { that: "vault_identity_alias.rc == 0" }
 
     - hashivault_identity_group_alias:
         name: "extest alias"
         group_name: extest
         state: absent
       register: vault_identity_alias
-    - assert: { that: "{{vault_identity_alias.changed}} == True" }
-    - assert: { that: "{{vault_identity_alias.rc}} == 0" }
+    - assert: { that: "vault_identity_alias is changed" }
+    - assert: { that: "vault_identity_alias.rc == 0" }

--- a/functional/test_init.yml
+++ b/functional/test_init.yml
@@ -8,24 +8,24 @@
         secret_threshold: 1
       register: 'vault_init'
     - block:
-      - assert: { that: "{{vault_init.rc}} == 0" }
-      when: "vault_init.changed == False"
+      - assert: { that: "vault_init.rc == 0" }
+      when: "vault_init is not changed"
     - block:
       - assert: { that: "'keys' in vault_init" }
       - assert: { that: "'root_token' in vault_init" }
-      - assert: { that: "{{vault_init.rc}} == 0" }
+      - assert: { that: "vault_init.rc == 0" }
       - set_fact:
           vault_keys: "{{vault_init['keys'] | join(' ')}}"
       - name: Unseal the vault
         hashivault_unseal:
           keys: '{{vault_keys}}'
         register: 'vault_unseal'
-      - assert: { that: "{{vault_unseal.changed}} == True" }
-      - assert: { that: "{{vault_unseal.status.progress}} == 0" }
-      - assert: { that: "{{vault_unseal.status.sealed}} == False" }
-      - assert: { that: "{{vault_unseal.rc}} == 0" }
+      - assert: { that: "vault_unseal is changed" }
+      - assert: { that: "vault_unseal.status.progress == 0" }
+      - assert: { that: "vault_unseal.status.sealed == False" }
+      - assert: { that: "vault_unseal.rc == 0" }
       - template:
           src: "{{playbook_dir}}/templates/vaultenv.sh.j2"
           dest: "{{playbook_dir}}/vaultenv.sh"
           mode: 0700
-      when: "vault_init.changed == True"
+      when: "vault_init is changed"

--- a/functional/test_k8_auth.yml
+++ b/functional/test_k8_auth.yml
@@ -17,8 +17,8 @@
         kubernetes_host: http://127.0.0.1:8443
         kubernetes_ca_cert: "{{ lookup('file', './cacert.pem') }}"
         token_reviewer_jwt: "{{ lookup('file', './jwt.jws') }}"
-    - assert: { that: "{{ k8s_module.changed }} == True" }
-    - assert: { that: "{{ k8s_module.rc }} == 0" }
+    - assert: { that: "k8s_module is changed" }
+    - assert: { that: "k8s_module.rc == 0" }
 
     - name: idempotent create config
       register: k8s_module
@@ -26,8 +26,8 @@
         kubernetes_host: http://127.0.0.1:8443
         kubernetes_ca_cert: "{{ lookup('file', './cacert.pem') }}"
         token_reviewer_jwt: "{{ lookup('file', './jwt.jws') }}"
-    - assert: { that: "{{ k8s_module.changed }} == False" }
-    - assert: { that: "{{ k8s_module.rc }} == 0" }
+    - assert: { that: "k8s_module is not changed" }
+    - assert: { that: "k8s_module.rc == 0" }
 
     - name: update config
       register: k8s_module
@@ -36,8 +36,8 @@
         kubernetes_ca_cert: "{{ lookup('file', './cacert.pem') }}"
         token_reviewer_jwt: "{{ lookup('file', './jwt.jws') }}"
         # issuer: bob hvac 0.10.2
-    - assert: { that: "{{ k8s_module.changed }} == True" }
-    - assert: { that: "{{ k8s_module.rc }} == 0" }
+    - assert: { that: "k8s_module is changed" }
+    - assert: { that: "k8s_module.rc == 0" }
 
     - name: create role delete
       hashivault_k8s_auth_role:
@@ -52,8 +52,8 @@
         bound_service_account_namespaces: ["default", "some-app"]
         token_type: service
       register: k8s_module
-    - assert: { that: "{{ k8s_module.changed }} == True" }
-    - assert: { that: "{{ k8s_module.rc }} == 0" }
+    - assert: { that: "k8s_module is changed" }
+    - assert: { that: "k8s_module.rc == 0" }
 
     - name: read role
       hashivault_read:
@@ -66,7 +66,7 @@
           - k8s_module.value.bound_service_account_names|sort == ["vault-auth"]|sort
           - k8s_module.value.bound_service_account_namespaces|sort == ["some-app","default"]|sort
           - k8s_module.value.token_type == 'service'
-    - assert: { that: "{{ k8s_module.rc }} == 0" }
+    - assert: { that: "k8s_module.rc == 0" }
 
     - name: create role idempotent
       hashivault_k8s_auth_role:
@@ -76,13 +76,13 @@
         bound_service_account_namespaces: ["default", "some-app"]
         token_type: service
       register: k8s_module
-    - assert: { that: "{{ k8s_module.changed }} == False" }
-    - assert: { that: "{{ k8s_module.rc }} == 0" }
+    - assert: { that: "k8s_module is not changed" }
+    - assert: { that: "k8s_module.rc == 0" }
 
     - name: create role delete
       hashivault_k8s_auth_role:
         name: "testk8srole"
         state: absent
       register: k8s_module
-    - assert: { that: "{{ k8s_module.changed }} == True" }
-    - assert: { that: "{{ k8s_module.rc }} == 0" }
+    - assert: { that: "k8s_module is changed" }
+    - assert: { that: "k8s_module.rc == 0" }

--- a/functional/test_kv2.yml
+++ b/functional/test_kv2.yml
@@ -15,8 +15,8 @@
         options:
           version: 2
       register: 'vault_secret_enable'
-    - assert: { that: "{{vault_secret_enable.changed}} == True" }
-    - assert: { that: "{{vault_secret_enable.rc}} == 0" }
+    - assert: { that: "vault_secret_enable is changed" }
+    - assert: { that: "vault_secret_enable.rc == 0" }
 
     - name: Enable same secret store again and check it doesn't fail
       hashivault_secret_engine:
@@ -25,8 +25,8 @@
         options:
           version: 2
       register: 'vault_secret_enable_twice'
-    - assert: { that: "{{vault_secret_enable_twice.changed}} == False" }
-    - assert: { that: "{{vault_secret_enable_twice.rc}} == 0" }
+    - assert: { that: "vault_secret_enable_twice is not changed" }
+    - assert: { that: "vault_secret_enable_twice.rc == 0" }
 
     - name: Write a value to the kv2 store
       hashivault_write:
@@ -36,9 +36,9 @@
         data:
             value: kv2_stuff
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret kv2/name written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret kv2/name written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update a value to the kv2 store
       hashivault_write:
@@ -49,9 +49,9 @@
         data:
             ingrediant: corn
       register: vault_update
-    - assert: { that: "{{vault_update.changed}} == True" }
-    - assert: { that: "'{{vault_update.msg}}' == 'Secret kv2/name written'" }
-    - assert: { that: "{{vault_update.rc}} == 0" }
+    - assert: { that: "vault_update is changed" }
+    - assert: { that: "vault_update.msg == 'Secret kv2/name written'" }
+    - assert: { that: "vault_update.rc == 0" }
 
     - name: Update a value to the kv2 store again
       hashivault_write:
@@ -62,8 +62,8 @@
         data:
             ingrediant: corn
       register: vault_update
-    - assert: { that: "{{vault_update.changed}} == False" }
-    - assert: { that: "{{vault_update.rc}} == 0" }
+    - assert: { that: "vault_update is not changed" }
+    - assert: { that: "vault_update.rc == 0" }
 
     - name: Read the new kv2 value
       hashivault_read:
@@ -72,7 +72,7 @@
         key: ingrediant
         version: 2
       register: vault_read
-    - assert: { that: "'{{vault_read.value}}' == 'corn'" }
+    - assert: { that: "vault_read.value == 'corn'" }
 
     - name: Read the kv2 value
       hashivault_read:
@@ -81,7 +81,7 @@
         key: value
         version: 2
       register: vault_read
-    - assert: { that: "'{{vault_read.value}}' == 'kv2_stuff'" }
+    - assert: { that: "vault_read.value == 'kv2_stuff'" }
 
     - name: Read the whole kv2 value
       hashivault_read:
@@ -102,7 +102,7 @@
 
     - set_fact:
        looky_kv2: "{{lookup('hashivault', 'name', 'value', version=2, mount_point='kv2')}}"
-    - assert: { that: "'{{looky_kv2}}' == 'kv2_stuff'" }
+    - assert: { that: "looky_kv2 == 'kv2_stuff'" }
 
     - name: Delete kv2 secret
       hashivault_delete:
@@ -110,9 +110,9 @@
         secret: name
         version: 2
       register: 'vault_secret_delete'
-    - assert: { that: "{{vault_secret_delete.changed}} == True" }
-    - assert: { that: "{{vault_secret_delete.rc}} == 0" }
-    - assert: { that: "'{{vault_secret_delete.msg}}' == 'Secret kv2/name deleted'" }
+    - assert: { that: "vault_secret_delete is changed" }
+    - assert: { that: "vault_secret_delete.rc == 0" }
+    - assert: { that: "vault_secret_delete.msg == 'Secret kv2/name deleted'" }
 
     - name: Make sure kv2 value is gone
       hashivault_read:
@@ -121,8 +121,8 @@
         version: 2
       register: 'vault_read'
       failed_when: False
-    - assert: { that: "{{vault_read.changed}} == False" }
-    - assert: { that: "'{{vault_read.msg}}' == 'Secret kv2/name is not in vault'" }
+    - assert: { that: "vault_read is not changed" }
+    - assert: { that: "vault_read.msg == 'Secret kv2/name is not in vault'" }
 
     - name: Tune kv2 secret store
       hashivault_secret_engine:
@@ -134,8 +134,8 @@
           default_lease_ttl: 3600
           max_lease_ttl: 8600
       register: vault_tune
-    - assert: { that: "{{ vault_tune.changed }} == True" }
-    - assert: { that: "{{ vault_tune.rc }} == 0" }
+    - assert: { that: "vault_tune is changed" }
+    - assert: { that: "vault_tune.rc == 0" }
 
     - name: Idempotent tuning kv2 secret store
       hashivault_secret_engine:
@@ -147,13 +147,13 @@
           default_lease_ttl: 3600
           max_lease_ttl: 8600
       register: vault_tune
-    - assert: { that: "{{ vault_tune.changed }} == False" }
-    - assert: { that: "{{ vault_tune.rc }} == 0" }
+    - assert: { that: "vault_tune is not changed" }
+    - assert: { that: "vault_tune.rc == 0" }
 
     - name: Disable kv2 secret store
       hashivault_secret_engine:
         name: "kv2"
         state: absent
       register: 'vault_secret_disable'
-    - assert: { that: "{{vault_secret_disable.changed}} == True" }
-    - assert: { that: "{{vault_secret_disable.rc}} == 0" }
+    - assert: { that: "vault_secret_disable is changed" }
+    - assert: { that: "vault_secret_disable.rc == 0" }

--- a/functional/test_ldap_group.yml
+++ b/functional/test_ldap_group.yml
@@ -20,14 +20,14 @@
       hashivault_auth_ldap:
         ldap_url: ldap://localhost
       register: ldap_module
-    - assert: { that: "{{ ldap_module.changed }} == True" }
-    - assert: { that: "{{ ldap_module.rc }} == 0" }
+    - assert: { that: "ldap_module is changed" }
+    - assert: { that: "ldap_module.rc == 0" }
 
     - name: ldap configuration is idempotent
       hashivault_auth_ldap:
         ldap_url: ldap://localhost
       register: ldap_module_idempotent
-    - assert: { that: "{{ ldap_module_idempotent.changed }} == False" }
+    - assert: { that: "ldap_module_idempotent is not changed" }
 
     - name: remove ldap group
       hashivault_ldap_group:
@@ -40,7 +40,7 @@
         state: present
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: chg policies - add functional_testing_policy_one
       hashivault_ldap_group:
@@ -50,7 +50,7 @@
           - functional_testing_policy_one
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == True" }
+    - assert: { that: "chg_policies is changed" }
 
     - name: duplicate policies
       hashivault_ldap_group:
@@ -60,7 +60,7 @@
           - functional_testing_policy_one
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == False" }
+    - assert: { that: "chg_policies is not changed" }
 
     - name: chg policies - add functional_testing_policy_two
       hashivault_ldap_group:
@@ -71,7 +71,7 @@
           - functional_testing_policy_two
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == True" }
+    - assert: { that: "chg_policies is changed" }
 
     - name: chg policies - remove functional_testing_policy_one
       hashivault_ldap_group:
@@ -81,4 +81,4 @@
           - functional_testing_policy_two
       register: chg_policies
 
-    - assert: { that: "{{ chg_policies.changed }} == True" }
+    - assert: { that: "chg_policies is changed" }

--- a/functional/test_list.yml
+++ b/functional/test_list.yml
@@ -43,7 +43,7 @@
         secret: 'whatutalkinbout'
       register: vault_list
       failed_when: False
-    - assert: { that: "vault_list.changed == False" }
+    - assert: { that: "vault_list is not changed" }
     - assert: { that: "vault_list.rc == 1" }
     - assert: { that: "vault_list.msg == 'Secret does not exist: secret/whatutalkinbout'" }
 
@@ -89,7 +89,7 @@
         version: 2
       register: vault_list
       failed_when: False
-    - assert: { that: "vault_list.changed == False" }
+    - assert: { that: "vault_list is not changed" }
     - assert: { that: "vault_list.rc == 1" }
     - assert: { that: "vault_list.msg == 'Secret does not exist: dummyv2/whatutalkinbout'" }
 

--- a/functional/test_lookup.yml
+++ b/functional/test_lookup.yml
@@ -19,23 +19,23 @@
       - 'two'
       - 'three'
   tasks:
-    - assert: { that: "'{{vars_foo}}' == 'new'" }
+    - assert: { that: "vars_foo == 'new'" }
 
     - set_fact:
         a_set_fie: "{{lookup('hashivault', '{{name_root}}', 'fie')}}"
-    - assert: { that: "'{{a_set_fie}}' == 'fum'" }
+    - assert: { that: "a_set_fie == 'fum'" }
 
     - set_fact:
         a_set_fie: "{{lookup('hashivault', '{{name_folder}}', 'height')}}"
-    - assert: { that: "'{{a_set_fie}}' == 'tall'" }
+    - assert: { that: "a_set_fie == 'tall'" }
 
     - set_fact:
         a_set_dict: "{{lookup('hashivault', '{{name_dict}}', 'foo')}}"
-    - assert: { that: "'{{a_set_dict}}' == 'bar'" }
+    - assert: { that: "a_set_dict == 'bar'" }
 
     - set_fact:
         a_set_array: "{{lookup('hashivault', '{{name_array}}', 'value') | first}}"
-    - assert: { that: "'{{a_set_array}}' == 'one'" }
+    - assert: { that: "a_set_array == 'one'" }
 
     - set_fact:
         a_set_dict_all: "{{lookup('hashivault', '{{name_dict}}')}}"
@@ -47,8 +47,8 @@
 
     - set_fact:
         looky_secret: "{{lookup('hashivault', '{{namespace}}fourofour/notfound', 'value', default='noob')}}"
-    - assert: { that: "'{{looky_secret}}' == 'noob'" }
+    - assert: { that: "looky_secret == 'noob'" }
 
     - set_fact:
         looky_secret: "{{lookup('hashivault', '{{name_root}}', 'fie', url='http://bogus', errors='ignore')}}"
-    - assert: { that: "'{{looky_secret}}' == ''" }
+    - assert: { that: "looky_secret == ''" }

--- a/functional/test_mounts.yml
+++ b/functional/test_mounts.yml
@@ -17,7 +17,7 @@
         state: present
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: skip with config defaults
       hashivault_secret_engine:
@@ -25,7 +25,7 @@
         state: present
       register: skip_config
 
-    - assert: { that: "{{ skip_config.changed }} == False" }
+    - assert: { that: "skip_config is not changed" }
 
     - name: changed with config vars
       hashivault_secret_engine:
@@ -34,7 +34,7 @@
         config: {'default_lease_ttl': 1234567}
       register: chg_config
 
-    - assert: { that: "{{ chg_config.changed }} == True" }
+    - assert: { that: "chg_config is changed" }
 
     - name: changed to version 2
       hashivault_secret_engine:
@@ -44,7 +44,7 @@
         options: {'version': '2'}
       register: chg_version
 
-    - assert: { that: "{{ chg_version.changed }} == True" }
+    - assert: { that: "chg_version is changed" }
 
     - name: dont fail when options passed to non kv
       hashivault_secret_engine:
@@ -55,7 +55,7 @@
         options: {'version': '2'}
       register: dont_pass_options
 
-    - assert: { that: "{{ dont_pass_options.changed }} == True" }
+    - assert: { that: "dont_pass_options is changed" }
 
     - name: cleanup 1
       hashivault_secret_engine:
@@ -66,7 +66,7 @@
         options: {'version': '2'}
       register: disable
 
-    - assert: { that: "{{ disable.changed }} == True" }
+    - assert: { that: "disable is changed" }
 
     - name: cleanup 2
       hashivault_secret_engine:
@@ -77,4 +77,4 @@
         options: {'version': '2'}
       register: disable2
 
-    - assert: { that: "{{ disable2.changed }} == True" }
+    - assert: { that: "disable2 is changed" }

--- a/functional/test_namespace.yml
+++ b/functional/test_namespace.yml
@@ -2,7 +2,7 @@
 - hosts: localhost
   connection: localhost
   tasks:
-    
+
     - hashivault_namespace:
         name: hvtest
         state: absent
@@ -11,48 +11,48 @@
         name: hvtest
       register: first_create
 
-    - assert: { that: "{{first_create.changed}} == True" }
+    - assert: { that: "first_create is changed" }
 
     - hashivault_namespace:
         name: hvtest
       register: idem_create
 
-    - assert: { that: "{{idem_create.changed}} == False" }
+    - assert: { that: "idem_create is not changed" }
 
     - hashivault_namespace:
         name: child
         namespace: hvtest
       register: second_create
 
-    - assert: { that: "{{second_create.changed}} == True" }
-    
+    - assert: { that: "second_create is changed" }
+
     - hashivault_namespace:
         name: child
         namespace: hvtest
       register: second_idem_create
 
-    - assert: { that: "{{second_idem_create.changed}} == False" }
+    - assert: { that: "second_idem_create is not changed" }
 
     - hashivault_namespace:
         name: child2
         namespace: hvtest/child
       register: third_create
 
-    - assert: { that: "{{third_create.changed}} == True" }
+    - assert: { that: "third_create is changed" }
 
     - hashivault_namespace:
         name: child2
         namespace: hvtest/child
       register: third_idem_create
 
-    - assert: { that: "{{third_idem_create.changed}} == False" }
+    - assert: { that: "third_idem_create is not changed" }
 
     - hashivault_namespace:
         name: hvtest
         state: absent
       register: delete_fail
       failed_when: False
-    - assert: { that: "{{delete_fail.rc}} != 0" }
+    - assert: { that: "delete_fail.rc != 0" }
 
 
     - hashivault_namespace:
@@ -61,7 +61,7 @@
         state: absent
       register: delete_one
 
-    - assert: { that: "{{delete_one.changed}} == True" }
+    - assert: { that: "delete_one is changed" }
 
     - hashivault_namespace:
         name: child
@@ -69,18 +69,18 @@
         state: absent
       register: delete_two
 
-    - assert: { that: "{{delete_two.changed}} == True" }
+    - assert: { that: "delete_two is changed" }
 
     - hashivault_namespace:
         name: hvtest
         state: absent
       register: delete_three
 
-    - assert: { that: "{{delete_three.changed}} == True" }
+    - assert: { that: "delete_three is changed" }
 
     - hashivault_namespace:
         name: hvtest
         state: absent
       register: delete_idem
 
-    - assert: { that: "{{delete_idem.changed}} == False" }
+    - assert: { that: "delete_idem is not changed" }

--- a/functional/test_not_there.yml
+++ b/functional/test_not_there.yml
@@ -13,9 +13,9 @@
         key: 'value'
       register: 'vault_read'
       failed_when: False
-    - assert: { that: "{{vault_read.failed}} == False" }
-    - assert: { that: "{{vault_read.rc}} == 1" }
-    - assert: { that: "'{{vault_read.msg}}' == 'Secret secret/fourofour/nothome is not in vault'" }
+    - assert: { that: "vault_read.failed == False" }
+    - assert: { that: "vault_read.rc == 1" }
+    - assert: { that: "vault_read.msg == 'Secret secret/fourofour/nothome is not in vault'" }
 
     - name: Nonexistent secret path with empty default
       hashivault_read:
@@ -23,9 +23,9 @@
         key: 'value'
         default: ''
       register: 'vault_read'
-    - assert: { that: "'{{vault_read.value}}' == ''" }
-    - assert: { that: "{{vault_read.failed}} == False" }
-    - assert: { that: "{{vault_read.rc}} == 0" }
+    - assert: { that: "vault_read.value == ''" }
+    - assert: { that: "vault_read.failed == False" }
+    - assert: { that: "vault_read.rc == 0" }
 
     - name: Nonexistent secret path with default
       hashivault_read:
@@ -33,11 +33,11 @@
         key: 'value'
         default: 'carseat'
       register: 'vault_read'
-    - assert: { that: "'{{vault_read.value}}' == 'carseat'" }
+    - assert: { that: "vault_read.value == 'carseat'" }
 
     - set_fact:
         looky_secret: "{{lookup('hashivault', '{{secret_name}}', 'value', default='headrest')}}"
-    - assert: { that: "'{{looky_secret}}' == 'headrest'" }
+    - assert: { that: "looky_secret == 'headrest'" }
 
     - name: Write new different value to secret store
       hashivault_write:
@@ -51,12 +51,12 @@
         key: 'value'
         default: 'better'
       register: 'vault_read'
-    - assert: { that: "'{{vault_read.value}}' == 'better'" }
+    - assert: { that: "vault_read.value == 'better'" }
 
     - set_fact:
         looky_secret: "{{lookup('hashivault', '{{secret_name}}', 'othervalue', default='noob')}}"
-    - assert: { that: "'{{looky_secret}}' == 'one'" }
+    - assert: { that: "looky_secret == 'one'" }
 
     - set_fact:
         looky_secret: "{{lookup('hashivault', '{{secret_name}}', 'value', default='noob')}}"
-    - assert: { that: "'{{looky_secret}}' == 'noob'" }
+    - assert: { that: "looky_secret == 'noob'" }

--- a/functional/test_oidc_auth_method_config.yml
+++ b/functional/test_oidc_auth_method_config.yml
@@ -20,7 +20,7 @@
       register: fail_config
       failed_when: false
 
-    - assert: { that: "{{ fail_config.changed }} == False" }
+    - assert: { that: "fail_config is not changed" }
 
     - name: enable oidc auth method
       hashivault_auth_method:
@@ -33,7 +33,7 @@
         oidc_client_secret: "{{ oidc_client_secret }}"
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: attempt 2nd config with same values
       hashivault_oidc_auth_method_config:
@@ -41,7 +41,7 @@
         oidc_client_id: "{{ oidc_client_id }}"
       register: idem_config
 
-    - assert: { that: "{{ idem_config.changed }} == False" }
+    - assert: { that: "idem_config is not changed" }
 
     - name: attempt 3rd config with different values
       hashivault_oidc_auth_method_config:
@@ -50,4 +50,4 @@
         oidc_client_secret: pineapple
       register: overwrite_config
 
-    - assert: { that: "{{ overwrite_config.changed }} == True" }
+    - assert: { that: "overwrite_config is changed" }

--- a/functional/test_oidc_auth_role.yml
+++ b/functional/test_oidc_auth_role.yml
@@ -30,7 +30,7 @@
         token_policies: ["test"]
       register: success_config
 
-    - assert: { that: "{{ success_config.changed }} == True" }
+    - assert: { that: "success_config is changed" }
 
     - name: idempotently create role
       hashivault_oidc_auth_role:
@@ -40,7 +40,7 @@
         token_policies: ["test"]
       register: idem_config
 
-    - assert: { that: "{{ idem_config.changed }} == False" }
+    - assert: { that: "idem_config is not changed" }
 
     - name: delete role
       hashivault_oidc_auth_role:
@@ -49,4 +49,4 @@
         allowed_redirect_uris: ["https://123456.com/callback"]
       register: del_config
 
-    - assert: { that: "{{ del_config.changed }} == True" }
+    - assert: { that: "del_config is changed" }

--- a/functional/test_pki.yml
+++ b/functional/test_pki.yml
@@ -62,7 +62,7 @@
         backend: "pki"
         description: "Root pki engine"
       register: response
-    - assert: { that: "{{response.rc}} == 0" }
+    - assert: { that: "response.rc == 0" }
     - name: Generate Intermediate
       hashivault_pki_ca:
         mount_point: "{{mount_inter}}"
@@ -366,7 +366,7 @@
         description: "Root pki engine"
         state: absent
       register: response
-    - assert: { that: "{{response.rc}} == 0" }
+    - assert: { that: "response.rc == 0" }
     - name: Disable PKI secrets engine
       hashivault_secret_engine:
         name: "{{mount_root}}"
@@ -374,4 +374,4 @@
         description: "Root pki engine"
         state: absent
       register: response
-    - assert: { that: "{{response.rc}} == 0" }
+    - assert: { that: "response.rc == 0" }

--- a/functional/test_policy.yml
+++ b/functional/test_policy.yml
@@ -29,58 +29,58 @@
 
     - hashivault_policy_list:
       register: 'vault_policy_list'
-    - assert: { that: "{{vault_policy_list.changed}} == False" }
-    - assert: { that: "{{vault_policy_list.rc}} == 0" }
+    - assert: { that: "vault_policy_list is not changed" }
+    - assert: { that: "vault_policy_list.rc == 0" }
 
     - name: Delete a policy that doesn't exist and check that doesn't change or fail
       hashivault_policy:
         name: '{{namespace}}'
         state: absent
       register: 'vault_policy_delete'
-    - assert: { that: "{{vault_policy_delete.changed}} == False" }
-    - assert: { that: "{{vault_policy_delete.rc}} == 0" }
+    - assert: { that: "vault_policy_delete is not changed" }
+    - assert: { that: "vault_policy_delete.rc == 0" }
 
     - name: Set new policy
       hashivault_policy:
         name: "{{namespace}}"
         rules: "{{rules}}"
       register: 'vault_policy'
-    - assert: { that: "{{vault_policy.changed}} == True" }
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy is changed" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: Set policy again and check that it doesn't change
       hashivault_policy:
         name: "{{namespace}}"
         rules: "{{rules}}"
       register: 'vault_policy_twice'
-    - assert: { that: "{{vault_policy_twice.changed}} == False" }
-    - assert: { that: "{{vault_policy_twice.rc}} == 0" }
+    - assert: { that: "vault_policy_twice is not changed" }
+    - assert: { that: "vault_policy_twice.rc == 0" }
 
     - name: Get policy and make sure it set properly
       hashivault_policy_get:
         name: '{{namespace}}'
       register: 'vault_policy_get'
-    - assert: { that: "{{vault_policy_get.changed}} == False" }
+    - assert: { that: "vault_policy_get is not changed" }
     - set_fact:
         actual: "{{vault_policy_get.rules | regex_replace('\n', '')}}"
-    - assert: { that: "'{{expected}}' == '{{actual}}'" }
-    - assert: { that: "{{vault_policy_get.rc}} == 0" }
+    - assert: { that: "expected == actual" }
+    - assert: { that: "vault_policy_get.rc == 0" }
 
     - name: Make sure our new policy is in list
       hashivault_policy_list:
       register: 'vault_policy_list'
-    - assert: { that: "{{vault_policy_list.changed}} == False" }
+    - assert: { that: "vault_policy_list is not changed" }
     - fail: msg="policy {{namespace}} not in list"
       when: namespace not in vault_policy_list.policies
-    - assert: { that: "{{vault_policy_list.rc}} == 0" }
+    - assert: { that: "vault_policy_list.rc == 0" }
 
     - name: Set new policy from file
       hashivault_policy:
         name: "{{namespace}}"
         rules_file: "templates/policy_rules.hcl"
       register: 'vault_policy'
-    - assert: { that: "{{vault_policy.changed}} == True" }
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy is changed" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: Validate file policy
       hashivault_policy_get:
@@ -88,56 +88,56 @@
       register: 'vault_policy_get'
     - set_fact:
         actual: "{{vault_policy_get.rules | regex_replace('\n', '') | regex_replace(' ', '')}}"
-    - assert: { that: "'{{bobs_expected}}' == '{{actual}}'" }
+    - assert: { that: "bobs_expected == actual" }
 
     - name: Get rid of our new policy
       hashivault_policy:
         name: '{{namespace}}'
         state: absent
       register: 'vault_policy_delete'
-    - assert: { that: "{{vault_policy_delete.changed}} == True" }
-    - assert: { that: "{{vault_policy_delete.rc}} == 0" }
+    - assert: { that: "vault_policy_delete is changed" }
+    - assert: { that: "vault_policy_delete.rc == 0" }
 
     - name: Make sure our new policy is gone
       hashivault_policy_list:
       register: 'vault_policy_list'
-    - assert: { that: "{{vault_policy_list.changed}} == False" }
+    - assert: { that: "vault_policy_list is not changed" }
     - fail: msg="policy {{namespace}} in list"
       when: namespace in vault_policy_list.policies
-    - assert: { that: "{{vault_policy_list.rc}} == 0" }
+    - assert: { that: "vault_policy_list.rc == 0" }
 
     - name: Get bogus policy
       hashivault_policy_get:
         name: '{{namespace}}bogus'
       register: 'vault_policy_get'
       failed_when: False
-    - assert: { that: "{{vault_policy_get.changed}} == False" }
-    - assert: { that: "{{vault_policy_get.rc}} == 1" }
-    - assert: { that: "{{vault_policy_get.failed}} == False" }
-    - assert: { that: "'{{vault_policy_get.msg}}' == 'Policy \"terrybogus\" does not exist.'" }
+    - assert: { that: "vault_policy_get is not changed" }
+    - assert: { that: "vault_policy_get.rc == 1" }
+    - assert: { that: "vault_policy_get.failed == False" }
+    - assert: { that: "vault_policy_get.msg == 'Policy \"terrybogus\" does not exist.'" }
 
     - name: Set new policy from file
       hashivault_policy:
         name: bob
         rules_file: "templates/policy_rules.hcl"
       register: 'vault_policy'
-    - assert: { that: "{{vault_policy.changed}} == True" }
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy is changed" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: Get new from file policy and make sure it set properly
       hashivault_policy_get:
         name: bob
       register: 'vault_policy_get'
-    - assert: { that: "{{vault_policy_get.changed}} == False" }
+    - assert: { that: "vault_policy_get is not changed" }
     - set_fact:
         actual: "{{vault_policy_get.rules | regex_replace('\n', '') | regex_replace(' ', '')}}"
-    - assert: { that: "'{{bobs_expected}}' == '{{actual}}'" }
-    - assert: { that: "{{vault_policy_get.rc}} == 0" }
+    - assert: { that: "bobs_expected == actual" }
+    - assert: { that: "vault_policy_get.rc == 0" }
 
     - name: Delete our new policy from file
       hashivault_policy:
         name: bob
         state: absent
       register: 'vault_policy_delete'
-    - assert: { that: "{{vault_policy_delete.changed}} == True" }
-    - assert: { that: "{{vault_policy_delete.rc}} == 0" }
+    - assert: { that: "vault_policy_delete is changed" }
+    - assert: { that: "vault_policy_delete.rc == 0" }

--- a/functional/test_read.yml
+++ b/functional/test_read.yml
@@ -23,28 +23,28 @@
         secret: '{{name_root}}'
         key: foo
       register: vault_read
-    - assert: { that: "'{{vault_read.value}}' == 'new'" }
+    - assert: { that: "vault_read.value == 'new'" }
 
     - name: Read other secret value
       hashivault_read:
         secret: '{{name_root}}'
         key: fie
       register: vault_read
-    - assert: { that: "'{{vault_read.value}}' == 'fum'" }
+    - assert: { that: "vault_read.value == 'fum'" }
 
     - name: Read other secret folder
       hashivault_read:
         secret: '{{name_folder}}'
         key: height
       register: vault_read
-    - assert: { that: "'{{vault_read.value}}' == 'tall'" }
+    - assert: { that: "vault_read.value == 'tall'" }
 
     - name: Read secret dictionary
       hashivault_read:
         secret: '{{name_dict}}'
       register: vault_read
     - assert: { that: "vault_read.value == dict_value" }
-    - assert: { that: "{{vault_read.rc}} == 0" }
+    - assert: { that: "vault_read.rc == 0" }
 
     - name: Read array type secret and make sure it matches
       hashivault_read:
@@ -52,10 +52,10 @@
         key: value
       register: vault_read
     - assert: { that: "vault_read.value == array_value" }
-    - assert: { that: "'{{vault_read.value[0]}}' == '{{array_value[0]}}'" }
-    - assert: { that: "'{{vault_read.value[1]}}' == '{{array_value[1]}}'" }
-    - assert: { that: "'{{vault_read.value[2]}}' == '{{array_value[2]}}'" }
+    - assert: { that: "vault_read.value[0] == array_value[0]" }
+    - assert: { that: "vault_read.value[1] == array_value[1]" }
+    - assert: { that: "vault_read.value[2] == array_value[2]" }
 
     - set_fact:
         looky_secret: "{{lookup('hashivault', '{{name_array}}', 'value') | first}}"
-    - assert: { that: "'{{looky_secret}}' == 'one'" }
+    - assert: { that: "looky_secret == 'one'" }

--- a/functional/test_read_write_file.yml
+++ b/functional/test_read_write_file.yml
@@ -34,7 +34,7 @@
 
     - assert:
         that:
-          - "{{vault_write_from_file.changed}} == True"
+          - "vault_write_from_file is changed"
 
     - name: read file with hashivault_read
       hashivault_read:
@@ -44,7 +44,7 @@
 
     - assert:
         that:
-          - "'{{ gen_file_encoded.content }}' == '{{ secret_contents.value }}'"
+          - "gen_file_encoded.content == secret_contents.value"
     ########################################################
 
 
@@ -81,7 +81,7 @@
 
     - assert:
         that:
-          - "{{ results.failed }} == True"
+          - "results.failed == True"
 
     - name: read file with hashivault_read_to_file
       hashivault_read_to_file:
@@ -93,7 +93,7 @@
 
     - assert:
         that:
-          - "{{ results.rc }} == 0"
+          - "results.rc == 0"
     ########################################################
 
 
@@ -110,7 +110,7 @@
 
     - assert:
         that:
-          - "'{{ results.mode }}' == '0777'"
+          - "results.mode == '0777'"
     ########################################################
 
 
@@ -126,8 +126,8 @@
 
     - assert:
         that:
-          - "{{vault_write.changed}} == True"
-          - "'{{vault_write.msg}}' == 'Secret secret/old_secret written'"
+          - "vault_write is changed"
+          - "vault_write.msg == 'Secret secret/old_secret written'"
 
     - name: write file to old secret
       hashivault_write_from_file:
@@ -138,7 +138,7 @@
 
     - assert:
         that:
-          - "{{vault_write_from_file.changed}} == True"
+          - "vault_write_from_file is changed"
 
     - name: read file with hashivault_read
       hashivault_read:
@@ -148,7 +148,7 @@
 
     - assert:
         that:
-          - "'{{ gen_file_encoded.content }}' == '{{ secret_contents.value }}'"
+          - "gen_file_encoded.content == secret_contents.value"
 
     - name: read old key with hashivault_read
       hashivault_read:
@@ -158,7 +158,7 @@
 
     - assert:
         that:
-          - "'{{ secret_contents.value }}' == 'foo'"
+          - "secret_contents.value == 'foo'"
     ########################################################
 
 
@@ -174,7 +174,7 @@
 
     - assert:
         that:
-          - "{{vault_write_from_file.changed}} == True"
+          - "vault_write_from_file is changed"
 
     - name: write key with update == False (should remove old_key)
       hashivault_write_from_file:
@@ -186,7 +186,7 @@
 
     - assert:
         that:
-          - "{{vault_write_from_file.changed}} == True"
+          - "vault_write_from_file is changed"
 
     - name: read missing key
       hashivault_read:
@@ -197,7 +197,7 @@
 
     - assert:
         that:
-          - "{{ results.failed }} == True"
+          - "results.failed == True"
     ########################################################
 
     - name: hashivault_read_to_file with non base64 secret
@@ -208,9 +208,9 @@
         force: True
       register: results
       failed_when: False
-    - assert: { that: "{{results.changed}} == False" }
-    - assert: { that: "{{results.rc}} == 1" }
-    - assert: { that: "'{{results.msg}}' == 'Error base64 decoding secret old_secret/old_key: Incorrect padding'" }
+    - assert: { that: "results is not changed" }
+    - assert: { that: "results.rc == 1" }
+    - assert: { that: "results.msg == 'Error base64 decoding secret old_secret/old_key: Incorrect padding'" }
 
 
     - name: success hashivault_read_to_file with non base64 secret
@@ -221,9 +221,9 @@
         force: True
         base64: False
       register: results
-    - assert: { that: "{{results.changed}} == True" }
-    - assert: { that: "{{results.rc}} == 0" }
-    - assert: { that: "{{results.failed}} == False" }
+    - assert: { that: "results is changed" }
+    - assert: { that: "results.rc == 0" }
+    - assert: { that: "results.failed == False" }
 
     ########################################################
     # Clean up test files.

--- a/functional/test_rekey.yml
+++ b/functional/test_rekey.yml
@@ -7,15 +7,15 @@
     - name: Check rekey status
       hashivault_rekey_status:
       register: 'vault_rekey_status'
-    - assert: { that: "{{vault_rekey_status.changed}} == False" }
-    - assert: { that: "{{vault_rekey_status.rc}} == 0" }
+    - assert: { that: "vault_rekey_status is not changed" }
+    - assert: { that: "vault_rekey_status.rc == 0" }
 
     - block:
         - name: Cancel the rekey if one was started
           hashivault_rekey_cancel:
           register: 'vault_rekey_cancel'
-        - assert: { that: "{{vault_rekey_cancel.changed}} == True" }
-        - assert: { that: "{{vault_rekey_cancel.rc}} == 0" }
+        - assert: { that: "vault_rekey_cancel is changed" }
+        - assert: { that: "vault_rekey_cancel.rc == 0" }
       when: "vault_rekey_status.status.started == True"
 
     - name: Start a rekey
@@ -23,46 +23,46 @@
         secret_shares: 1
         secret_threshold: 1
       register: 'vault_rekey_init'
-    - assert: { that: "{{vault_rekey_init.changed}} == True" }
-    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.started}} == True" }
-    - assert: { that: "{{vault_rekey_init.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.verification_required}} == False" }
+    - assert: { that: "vault_rekey_init is changed" }
+    - assert: { that: "vault_rekey_init.status.progress == 0" }
+    - assert: { that: "vault_rekey_init.status.started == True" }
+    - assert: { that: "vault_rekey_init.rc == 0" }
+    - assert: { that: "vault_rekey_init.status.verification_required == False" }
 
     - name: Make sure the rekey started
       hashivault_rekey_status:
       register: 'vault_rekey_status'
-    - assert: { that: "{{vault_rekey_status.changed}} == False" }
-    - assert: { that: "{{vault_rekey_status.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
-    - assert: { that: "{{vault_rekey_status.status.started}} == True" }
+    - assert: { that: "vault_rekey_status is not changed" }
+    - assert: { that: "vault_rekey_status.rc == 0" }
+    - assert: { that: "vault_rekey_init.status.progress == 0" }
+    - assert: { that: "vault_rekey_status.status.started == True" }
 
     - name: Canel the rekey
       hashivault_rekey_cancel:
       register: 'vault_rekey_cancel'
-    - assert: { that: "{{vault_rekey_cancel.changed}} == True" }
-    - assert: { that: "{{vault_rekey_cancel.rc}} == 0" }
+    - assert: { that: "vault_rekey_cancel is changed" }
+    - assert: { that: "vault_rekey_cancel.rc == 0" }
 
     - name: Restart that rekey again
       hashivault_rekey_init:
         secret_shares: 1
         secret_threshold: 1
       register: 'vault_rekey_init'
-    - assert: { that: "{{vault_rekey_init.changed}} == True" }
-    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.started}} == True" }
-    - assert: { that: "{{vault_rekey_init.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.verification_required}} == False" }
+    - assert: { that: "vault_rekey_init is changed" }
+    - assert: { that: "vault_rekey_init.status.progress == 0" }
+    - assert: { that: "vault_rekey_init.status.started == True" }
+    - assert: { that: "vault_rekey_init.rc == 0" }
+    - assert: { that: "vault_rekey_init.status.verification_required == False" }
 
     - name: Update the rekey
       hashivault_rekey:
         key: "{{ unseal_key }}"
         nonce: "{{ vault_rekey_init.status.nonce }}"
       register: 'vault_rekey'
-    - assert: { that: "{{vault_rekey.changed}} == True" }
-    - assert: { that: "{{vault_rekey.rc}} == 0" }
-    - assert: { that: "{{vault_rekey.status.complete}} == True" }
-    - assert: { that: "{{vault_rekey.status.verification_required}} == False" }
+    - assert: { that: "vault_rekey is changed" }
+    - assert: { that: "vault_rekey.rc == 0" }
+    - assert: { that: "vault_rekey.status.complete == True" }
+    - assert: { that: "vault_rekey.status.verification_required == False" }
 
     - name: Update vaultenv.sh with new keys
       lineinfile:

--- a/functional/test_rekey_verify.yml
+++ b/functional/test_rekey_verify.yml
@@ -7,15 +7,15 @@
     - name: Check rekey status
       hashivault_rekey_status:
       register: 'vault_rekey_status'
-    - assert: { that: "{{vault_rekey_status.changed}} == False" }
-    - assert: { that: "{{vault_rekey_status.rc}} == 0" }
+    - assert: { that: "vault_rekey_status is not changed" }
+    - assert: { that: "vault_rekey_status.rc == 0" }
 
     - block:
         - name: Cancel the rekey if one was started
           hashivault_rekey_cancel:
           register: 'vault_rekey_cancel'
-        - assert: { that: "{{vault_rekey_cancel.changed}} == True" }
-        - assert: { that: "{{vault_rekey_cancel.rc}} == 0" }
+        - assert: { that: "vault_rekey_cancel is changed" }
+        - assert: { that: "vault_rekey_cancel.rc == 0" }
       when: "vault_rekey_status.status.started == True"
 
     - name: Start a rekey
@@ -24,25 +24,25 @@
         secret_threshold: 1
         verification_required: True
       register: 'vault_rekey_init'
-    - assert: { that: "{{vault_rekey_init.changed}} == True" }
-    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.started}} == True" }
-    - assert: { that: "{{vault_rekey_init.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.verification_required}} == True" }
+    - assert: { that: "vault_rekey_init is changed" }
+    - assert: { that: "vault_rekey_init.status.progress == 0" }
+    - assert: { that: "vault_rekey_init.status.started == True" }
+    - assert: { that: "vault_rekey_init.rc == 0" }
+    - assert: { that: "vault_rekey_init.status.verification_required == True" }
 
     - name: Make sure the rekey started
       hashivault_rekey_status:
       register: 'vault_rekey_status'
-    - assert: { that: "{{vault_rekey_status.changed}} == False" }
-    - assert: { that: "{{vault_rekey_status.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
-    - assert: { that: "{{vault_rekey_status.status.started}} == True" }
+    - assert: { that: "vault_rekey_status is not changed" }
+    - assert: { that: "vault_rekey_status.rc == 0" }
+    - assert: { that: "vault_rekey_init.status.progress == 0" }
+    - assert: { that: "vault_rekey_status.status.started == True" }
 
     - name: Canel the rekey
       hashivault_rekey_cancel:
       register: 'vault_rekey_cancel'
-    - assert: { that: "{{vault_rekey_cancel.changed}} == True" }
-    - assert: { that: "{{vault_rekey_cancel.rc}} == 0" }
+    - assert: { that: "vault_rekey_cancel is changed" }
+    - assert: { that: "vault_rekey_cancel.rc == 0" }
 
     - name: Restart that rekey again
       hashivault_rekey_init:
@@ -50,31 +50,31 @@
         secret_threshold: 1
         verification_required: True
       register: 'vault_rekey_init'
-    - assert: { that: "{{vault_rekey_init.changed}} == True" }
-    - assert: { that: "{{vault_rekey_init.status.progress}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.started}} == True" }
-    - assert: { that: "{{vault_rekey_init.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_init.status.verification_required}} == True" }
+    - assert: { that: "vault_rekey_init is changed" }
+    - assert: { that: "vault_rekey_init.status.progress == 0" }
+    - assert: { that: "vault_rekey_init.status.started == True" }
+    - assert: { that: "vault_rekey_init.rc == 0" }
+    - assert: { that: "vault_rekey_init.status.verification_required == True" }
 
     - name: Update the rekey
       hashivault_rekey:
         key: "{{ unseal_key }}"
         nonce: "{{ vault_rekey_init.status.nonce }}"
       register: 'vault_rekey'
-    - assert: { that: "{{vault_rekey.changed}} == True" }
-    - assert: { that: "{{vault_rekey.rc}} == 0" }
-    - assert: { that: "{{vault_rekey.status.complete}} == True" }
-    - assert: { that: "{{vault_rekey.status.verification_required}} == True" }
+    - assert: { that: "vault_rekey is changed" }
+    - assert: { that: "vault_rekey.rc == 0" }
+    - assert: { that: "vault_rekey.status.complete == True" }
+    - assert: { that: "vault_rekey.status.verification_required == True" }
 
     - name: Verify the rekey
       hashivault_rekey_verify:
         key: "{{ vault_rekey['status']['keys'][0] }}"
         nonce: "{{ vault_rekey.status.verification_nonce }}"
       register: 'vault_rekey_verify'
-    - assert: { that: "{{vault_rekey_verify.changed}} == True" }
-    - assert: { that: "{{vault_rekey_verify.rc}} == 0" }
-    - assert: { that: "{{vault_rekey_verify.status.complete}} == True" }
-    - assert: { that: "'{{vault_rekey_verify.status.nonce}}' == '{{vault_rekey.status.verification_nonce}}'" }
+    - assert: { that: "vault_rekey_verify is changed" }
+    - assert: { that: "vault_rekey_verify.rc == 0" }
+    - assert: { that: "vault_rekey_verify.status.complete == True" }
+    - assert: { that: "vault_rekey_verify.status.nonce == vault_rekey.status.verification_nonce" }
 
     - name: Update vaultenv.sh with new keys
       lineinfile:

--- a/functional/test_secret.yml
+++ b/functional/test_secret.yml
@@ -31,9 +31,9 @@
               - two
               - three
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret {{namespace}}/secret_name written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret ' + namespace + '/secret_name written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Write again no change
       hashivault_secret:
@@ -46,9 +46,9 @@
             - two
             - three
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret {{namespace}}/secret_name unchanged'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "vault_write.msg == 'Secret ' + namespace + '/secret_name unchanged'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Write again with change
       hashivault_secret:
@@ -61,8 +61,8 @@
             - two
             - four
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - hashivault_read:
         mount_point: '{{namespace}}'
@@ -70,7 +70,7 @@
         version: 2
       register: vault_read
     - assert: { that: 'vault_read.value == {"fie": ["one", "two", "four"], "foo": "foe"}' }
-    - assert: { that: "{{vault_read.rc}} == 0" }
+    - assert: { that: "vault_read.rc == 0" }
 
     - name: Write again with change
       hashivault_secret:
@@ -80,8 +80,8 @@
         data:
           foo: future
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - hashivault_read:
         mount_point: '{{namespace}}'
@@ -89,7 +89,7 @@
         version: 2
       register: vault_read
     - assert: { that: 'vault_read.value == {"fie": ["one", "two", "four"], "foo": "future"}' }
-    - assert: { that: "{{vault_read.rc}} == 0" }
+    - assert: { that: "vault_read.rc == 0" }
 
     - name: Write secret in folder
       hashivault_secret:
@@ -98,9 +98,9 @@
         data:
           height: tall
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret {{namespace}}/name/folder written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret ' + namespace + '/name/folder written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Initial ttl values
       hashivault_secret:
@@ -110,7 +110,7 @@
           ttl:     36000s
           max_ttl: 480s
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
+    - assert: { that: "vault_write is changed" }
 
     - name: Update minute ttl secret
       hashivault_secret:
@@ -119,7 +119,7 @@
         data:
           ttl:      600m
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update hour ttl secret
       hashivault_secret:
@@ -128,7 +128,7 @@
         data:
           ttl:      10h
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update second ttl secret
       hashivault_secret:
@@ -137,7 +137,7 @@
         data:
           ttl:      36000s
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update second ttl secret no s
       hashivault_secret:
@@ -146,7 +146,7 @@
         data:
           ttl:      36000
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update second ttl secret new value
       hashivault_secret:
@@ -155,7 +155,7 @@
         data:
           ttl:      36001s
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
+    - assert: { that: "vault_write is changed" }
 
     - name: Write a secret to mess up no_log
       hashivault_secret:
@@ -169,8 +169,8 @@
           false: False
           true: True
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Delete a secret
       hashivault_secret:
@@ -178,9 +178,9 @@
         mount_point: '{{namespace}}'
         secret: no_log
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret {{namespace}}/no_log deleted'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret ' + namespace + '/no_log deleted'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Delete a secret again
       hashivault_secret:
@@ -188,6 +188,6 @@
         mount_point: '{{namespace}}'
         secret: no_log
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret {{namespace}}/no_log nonexistent'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "vault_write.msg == 'Secret ' + namespace + '/no_log nonexistent'" }
+    - assert: { that: "vault_write.rc == 0" }

--- a/functional/test_secret_engine.yml
+++ b/functional/test_secret_engine.yml
@@ -19,9 +19,9 @@
         backend: generic
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == True" }
-    - assert: { that: "{{ engine_result.changed }} == True" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == True" }
+    - assert: { that: "engine_result is changed" }
 
     - name: create idempotent
       hashivault_secret_engine:
@@ -29,9 +29,9 @@
         backend: generic
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == False" }
-    - assert: { that: "{{ engine_result.changed }} == False" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == False" }
+    - assert: { that: "engine_result is not changed" }
 
     - name: update description
       hashivault_secret_engine:
@@ -40,9 +40,9 @@
         description: 'vroom'
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == False" }
-    - assert: { that: "{{ engine_result.changed }} == True" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == False" }
+    - assert: { that: "engine_result is changed" }
 
     - name: update description idempotent
       hashivault_secret_engine:
@@ -51,9 +51,9 @@
         description: 'vroom'
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == False" }
-    - assert: { that: "{{ engine_result.changed }} == False" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == False" }
+    - assert: { that: "engine_result is not changed" }
 
     - name: update configuration
       hashivault_secret_engine:
@@ -63,9 +63,9 @@
           default_lease_ttl: 2764799
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == False" }
-    - assert: { that: "{{ engine_result.changed }} == True" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == False" }
+    - assert: { that: "engine_result is changed" }
 
     - name: update configuration idempotent
       hashivault_secret_engine:
@@ -75,9 +75,9 @@
           default_lease_ttl: 2764799
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == False" }
-    - assert: { that: "{{ engine_result.changed }} == False" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == False" }
+    - assert: { that: "engine_result is not changed" }
 
     - name: create kv
       hashivault_secret_engine:
@@ -85,9 +85,9 @@
         backend: kv
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == True" }
-    - assert: { that: "{{ engine_result.changed }} == True" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == True" }
+    - assert: { that: "engine_result is changed" }
 
     - name: update kv
       hashivault_secret_engine:
@@ -96,6 +96,6 @@
         description: 'kv engine'
         state: enabled
       register: engine_result
-    - assert: { that: "{{ engine_result.rc }} == 0" }
-    - assert: { that: "{{ engine_result.created }} == False" }
-    - assert: { that: "{{ engine_result.changed }} == True" }
+    - assert: { that: "engine_result.rc == 0" }
+    - assert: { that: "engine_result.created == False" }
+    - assert: { that: "engine_result is changed" }

--- a/functional/test_secret_list.yml
+++ b/functional/test_secret_list.yml
@@ -5,8 +5,7 @@
     - name: List secret stores
       hashivault_secret_list:
       register: 'vault_secret_list'
-    - assert: { that: "{{vault_secret_list.changed}} == False" }
-    - assert: { that: "{{vault_secret_list.failed}} == False" }
+    - assert: { that: "vault_secret_list is not changed" }
+    - assert: { that: "vault_secret_list.failed == False" }
     - assert: { that: "'backends' in vault_secret_list" }
-    - assert: { that: "{{vault_secret_list.rc}} == 0" }
-
+    - assert: { that: "vault_secret_list.rc == 0" }

--- a/functional/test_ssh_role.yml
+++ b/functional/test_ssh_role.yml
@@ -21,27 +21,27 @@
         name: "sshrole_test_user_original"
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: Set another ssh role policy
       hashivault_policy:
         name: "sshrole_test_user"
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: delete role
       hashivault_ssh_role:
         name: testrole
         state: absent
       failed_when: false
-    
+
     - name: list ssh roles empty
       hashivault_ssh_role_list:
       register: 'vault_role_list'
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
-    - assert: { that: "{{vault_role_list.data|length}} == 0"}
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
+    - assert: { that: "vault_role_list.data|length == 0"}
 
     - name: create role
       hashivault_ssh_role:
@@ -52,8 +52,8 @@
           allow_host_certificates: true
         state: present
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: update role
       hashivault_ssh_role:
@@ -62,8 +62,8 @@
           allowed_users: sshrole_test_user
         state: present
       register: 'vault_role_update'
-    - assert: { that: "{{vault_role_update.changed}} == True" }
-    - assert: { that: "{{vault_role_update.rc}} == 0" }
+    - assert: { that: "vault_role_update is changed" }
+    - assert: { that: "vault_role_update.rc == 0" }
 
     - name: update role idempotent
       hashivault_ssh_role:
@@ -73,13 +73,13 @@
           allow_host_certificates: true
         state: present
       register: 'vault_role_update'
-    - assert: { that: "{{vault_role_update.changed}} == False" }
-    - assert: { that: "{{vault_role_update.rc}} == 0" }
+    - assert: { that: "vault_role_update is not changed" }
+    - assert: { that: "vault_role_update.rc == 0" }
 
     - name: list ssh roles
       hashivault_ssh_role_list:
       register: 'vault_role_list'
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
     - fail: msg="role testrole not in list {{vault_role_list.data}}"
       when: '"testrole" not in vault_role_list.data'

--- a/functional/test_ssh_role_check_mode.yml
+++ b/functional/test_ssh_role_check_mode.yml
@@ -11,8 +11,8 @@
         state: present
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == False" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is not changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: create ssh role check_mode does not exist
       hashivault_ssh_role:
@@ -23,8 +23,8 @@
         state: present
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: delete ssh role check_mode exists
       hashivault_ssh_role:
@@ -32,8 +32,8 @@
         state: absent
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: delete ssh role check_mode does not exist
       hashivault_ssh_role:
@@ -41,14 +41,14 @@
         state: absent
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == False" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is not changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: list ssh roles check_mode
       hashivault_ssh_role_list:
       register: 'vault_role_list'
       check_mode: true
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
     - fail: msg="role testrole not in list {{vault_role_list.data}}"
       when: '"testrole" not in vault_role_list.data'

--- a/functional/test_status.yml
+++ b/functional/test_status.yml
@@ -5,42 +5,42 @@
     - name: Get vault status and make sure it is unsealed
       hashivault_status:
       register: 'vault_status'
-    - assert: { that: "{{vault_status.changed}} == False" }
-    - assert: { that: "{{vault_status.status.progress}} == 0" }
-    - assert: { that: "{{vault_status.status.sealed}} == False" }
-    - assert: { that: "{{vault_status.rc}} == 0" }
+    - assert: { that: "vault_status is not changed" }
+    - assert: { that: "vault_status.status.progress == 0" }
+    - assert: { that: "vault_status.status.sealed == False" }
+    - assert: { that: "vault_status.rc == 0" }
 
     - name: Get hashivault_leader
       hashivault_leader:
       register: 'vault_status'
-    - assert: { that: "{{vault_status.changed}} == False" }
-    - assert: { that: "{{vault_status.status.ha_enabled}} == False" }
-    - assert: { that: "{{vault_status.rc}} == 0" }
+    - assert: { that: "vault_status is not changed" }
+    - assert: { that: "vault_status.status.ha_enabled == False" }
+    - assert: { that: "vault_status.rc == 0" }
 
     - name: Get hashivault_cluster_status
       hashivault_cluster_status:
       register: 'vault_status'
-    - assert: { that: "{{vault_status.changed}} == False" }
-    - assert: { that: "{{vault_status.rc}} == 0" }
+    - assert: { that: "vault_status is not changed" }
+    - assert: { that: "vault_status.rc == 0" }
 
     - name: Get hashivault_cluster_status
       hashivault_cluster_status:
         standby_ok: false
       register: 'vault_status'
-    - assert: { that: "{{vault_status.changed}} == False" }
-    - assert: { that: "{{vault_status.rc}} == 0" }
+    - assert: { that: "vault_status is not changed" }
+    - assert: { that: "vault_status.rc == 0" }
 
     - name: Get hashivault_cluster_status
       hashivault_cluster_status:
         method: GET
       register: 'vault_status'
-    - assert: { that: "{{vault_status.changed}} == False" }
-    - assert: { that: "{{vault_status.rc}} == 0" }
+    - assert: { that: "vault_status is not changed" }
+    - assert: { that: "vault_status.rc == 0" }
 
     - name: Get hashivault_cluster_status
       hashivault_cluster_status:
         standby_ok: false
         method: GET
       register: 'vault_status'
-    - assert: { that: "{{vault_status.changed}} == False" }
-    - assert: { that: "{{vault_status.rc}} == 0" }
+    - assert: { that: "vault_status is not changed" }
+    - assert: { that: "vault_status.rc == 0" }

--- a/functional/test_token_role.yml
+++ b/functional/test_token_role.yml
@@ -16,14 +16,14 @@
         name: "tokenrole_test_policy_original"
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: Set another token role policy
       hashivault_policy:
         name: "tokenrole_test_policy"
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: delete role
       hashivault_token_role:
@@ -34,9 +34,9 @@
     - name: list token roles empty
       hashivault_token_role_list:
       register: 'vault_role_list'
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
-    - assert: { that: "{{vault_role_list.data|length}} == 0"}
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
+    - assert: { that: "vault_role_list.data|length == 0"}
 
     - name: create role
       hashivault_token_role:
@@ -46,8 +46,8 @@
             - tokenrole_test_policy_original
         state: present
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: update role
       hashivault_token_role:
@@ -57,8 +57,8 @@
             - tokenrole_test_policy
         state: present
       register: 'vault_role_update'
-    - assert: { that: "{{vault_role_update.changed}} == True" }
-    - assert: { that: "{{vault_role_update.rc}} == 0" }
+    - assert: { that: "vault_role_update is changed" }
+    - assert: { that: "vault_role_update.rc == 0" }
 
     - name: update role idempotent
       hashivault_token_role:
@@ -68,13 +68,13 @@
             - tokenrole_test_policy
         state: present
       register: 'vault_role_update'
-    - assert: { that: "{{vault_role_update.changed}} == False" }
-    - assert: { that: "{{vault_role_update.rc}} == 0" }
+    - assert: { that: "vault_role_update is not changed" }
+    - assert: { that: "vault_role_update.rc == 0" }
 
     - name: list token roles
       hashivault_token_role_list:
       register: 'vault_role_list'
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
     - fail: msg="role testrole not in list {{vault_role_list.data}}"
       when: '"testrole" not in vault_role_list.data'

--- a/functional/test_token_role_check_mode.yml
+++ b/functional/test_token_role_check_mode.yml
@@ -11,8 +11,8 @@
         state: present
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == False" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is not changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: create token role check_mode does not exist
       hashivault_token_role:
@@ -23,8 +23,8 @@
         state: present
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: delete token role check_mode exists
       hashivault_token_role:
@@ -32,8 +32,8 @@
         state: absent
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == True" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: delete token role check_mode does not exist
       hashivault_token_role:
@@ -41,14 +41,14 @@
         state: absent
       check_mode: true
       register: 'vault_role_create'
-    - assert: { that: "{{vault_role_create.changed}} == False" }
-    - assert: { that: "{{vault_role_create.rc}} == 0" }
+    - assert: { that: "vault_role_create is not changed" }
+    - assert: { that: "vault_role_create.rc == 0" }
 
     - name: list token roles check_mode
       hashivault_token_role_list:
       register: 'vault_role_list'
       check_mode: true
-    - assert: { that: "{{vault_role_list.changed}} == False" }
-    - assert: { that: "{{vault_role_list.rc}} == 0" }
+    - assert: { that: "vault_role_list is not changed" }
+    - assert: { that: "vault_role_list.rc == 0" }
     - fail: msg="role testrole not in list {{vault_role_list.data}}"
       when: '"testrole" not in vault_role_list.data'

--- a/functional/test_tokens.yml
+++ b/functional/test_tokens.yml
@@ -37,8 +37,8 @@
       register: vault_policy
     - assert:
         that:
-          - "{{vault_policy.changed}} == True"
-          - "{{vault_policy.rc}} == 0"
+          - "vault_policy.changed == True"
+          - "vault_policy.rc == 0"
 
     - name: "Create a {{admin_name}} token, so we can stop using root token"
       hashivault_token_create:
@@ -49,8 +49,8 @@
       register: "vault_token_admin"
     - assert:
         that:
-          - "{{vault_token_admin.changed}} == True"
-          - "{{vault_token_admin.rc}} == 0"
+          - "vault_token_admin.changed == True"
+          - "vault_token_admin.rc == 0"
     - set_fact:
         new_root_token: "{{vault_token_admin['token']['auth']['client_token']}}"
 
@@ -60,8 +60,8 @@
       register: 'vault_policy_list'
     - assert:
         that:
-          - "{{vault_policy_list.changed}} == False"
-          - "{{vault_policy_list.rc}} == 0"
+          - "vault_policy_list.changed == False"
+          - "vault_policy_list.rc == 0"
 
     - name: "Lookup with root token"
       hashivault_token_lookup:
@@ -69,8 +69,8 @@
       register: "vault_token_lookup"
     - assert:
         that:
-          - "{{vault_token_lookup.changed}} == False"
-          - "{{vault_token_lookup.rc}} == 0"
+          - "vault_token_lookup.changed == False"
+          - "vault_token_lookup.rc == 0"
 
     - name: "Create a read-only policy"
       hashivault_policy:
@@ -80,8 +80,8 @@
       register: vault_policy
     - assert:
         that:
-          - "{{vault_policy.changed}} == True"
-          - "{{vault_policy.rc}} == 0"
+          - "vault_policy.changed == True"
+          - "vault_policy.rc == 0"
 
     - name: "Create a {{readonly_name}} token"
       hashivault_token_create:
@@ -93,8 +93,8 @@
       register: "vault_token_readonly"
     - assert:
         that:
-          - "{{vault_token_readonly.changed}} == True"
-          - "{{vault_token_readonly.rc}} == 0"
+          - "vault_token_readonly.changed == True"
+          - "vault_token_readonly.rc == 0"
     - set_fact:
         read_only_token: "{{vault_token_admin['token']['auth']['client_token']}}"
 
@@ -104,8 +104,8 @@
       register: 'vault_policy_list'
     - assert:
         that:
-          - "{{vault_policy_list.changed}} == False"
-          - "{{vault_policy_list.rc}} == 0"
+          - "vault_policy_list.changed == False"
+          - "vault_policy_list.rc == 0"
 
     - name: "Renew root token"
       hashivault_token_renew:
@@ -113,8 +113,8 @@
       register: "vault_token_renew"
     - assert:
         that:
-          - "{{vault_token_renew.changed}} == True"
-          - "{{vault_token_renew.rc}} == 0"
+          - "vault_token_renew.changed == True"
+          - "vault_token_renew.rc == 0"
 
     - name: "Revoke root token"
       hashivault_token_renew:
@@ -122,5 +122,5 @@
       register: "vault_token_revoke"
     - assert:
         that:
-          - "{{vault_token_revoke.changed}} == True"
-          - "{{vault_token_revoke.rc}} == 0"
+          - "vault_token_revoke.changed == True"
+          - "vault_token_revoke.rc == 0"

--- a/functional/test_unseal.yml
+++ b/functional/test_unseal.yml
@@ -5,7 +5,7 @@
     vault_keys:  "{{ lookup('env','VAULT_KEYS') }}"
   tasks:
     - assert:
-        that: "'{{vault_keys}}' != ''"
+        that: "vault_keys != ''"
         msg: "VAULT_KEYS must be set to run this test"
     - name: Get status of vault before unseal
       hashivault_status:
@@ -15,28 +15,28 @@
         - name: Vault is not sealed so seal it
           hashivault_seal:
           register: 'vault_seal'
-        - assert: { that: "{{vault_seal.changed}} == True" }
-        - assert: { that: "{{vault_seal.rc}} == 0" }
+        - assert: { that: "vault_seal is changed" }
+        - assert: { that: "vault_seal.rc == 0" }
       when: "vault_status.status.sealed == False"
 
     - name: Seal the vault but it is already sealed
       hashivault_seal:
       register: 'vault_seal_st'
-    - assert: { that: "{{vault_seal_st.changed}} == False" }
-    - assert: { that: "{{vault_seal_st.rc}} == 0" }
+    - assert: { that: "vault_seal_st is not changed" }
+    - assert: { that: "vault_seal_st.rc == 0" }
 
     - name: Unseal the vault
       hashivault_unseal:
         keys: '{{vault_keys}}'
       register: 'vault_unseal'
-    - assert: { that: "{{vault_unseal.changed}} == True" }
-    - assert: { that: "{{vault_unseal.status.progress}} == 0" }
-    - assert: { that: "{{vault_unseal.status.sealed}} == False" }
-    - assert: { that: "{{vault_unseal.rc}} == 0" }
+    - assert: { that: "vault_unseal is changed" }
+    - assert: { that: "vault_unseal.status.progress == 0" }
+    - assert: { that: "vault_unseal.status.sealed == False" }
+    - assert: { that: "vault_unseal.rc == 0" }
 
     - name: Unseal the vault but it is not sealed
       hashivault_unseal:
         keys: '{{vault_keys}}'
       register: 'vault_unseal_st'
-    - assert: { that: "{{vault_unseal_st.changed}} == False" }
-    - assert: { that: "{{vault_unseal_st.rc}} == 0" }
+    - assert: { that: "vault_unseal_st is not changed" }
+    - assert: { that: "vault_unseal_st.rc == 0" }

--- a/functional/test_userpass.yml
+++ b/functional/test_userpass.yml
@@ -7,10 +7,10 @@
     rules: >
         path "secret/userpass/*" {
           capabilities = ["create", "read", "update", "delete", "list"]
-        } 
+        }
         path "secret/userpass" {
           capabilities = ["list"]
-        } 
+        }
   tasks:
     - hashivault_auth_method:
         method_type: "userpass"
@@ -27,8 +27,8 @@
         name: "{{username}}"
         rules: "{{rules}}"
       register: vault_policy
-    - assert: { that: "{{vault_policy.changed}} == True" }
-    - assert: { that: "{{vault_policy.rc}} == 0" }
+    - assert: { that: "vault_policy is changed" }
+    - assert: { that: "vault_policy.rc == 0" }
 
     - name: Create user pass with policy
       hashivault_userpass:
@@ -37,8 +37,8 @@
         policies: "{{username}}"
       register: 'vault_userpass_create'
       no_log: True
-    - assert: { that: "{{vault_userpass_create.changed}} == True" }
-    - assert: { that: "{{vault_userpass_create.rc}} == 0" }
+    - assert: { that: "vault_userpass_create is changed" }
+    - assert: { that: "vault_userpass_create.rc == 0" }
 
     - name: Create user to delete with policy
       hashivault_userpass:
@@ -47,15 +47,15 @@
         policies: "{{username}}"
       register: 'vault_userpass_create'
       no_log: True
-    - assert: { that: "{{vault_userpass_create.changed}} == True" }
-    - assert: { that: "{{vault_userpass_create.rc}} == 0" }
+    - assert: { that: "vault_userpass_create is changed" }
+    - assert: { that: "vault_userpass_create.rc == 0" }
 
     - hashivault_userpass:
         name: "delete_{{username}}"
         state: absent
       register: 'vault_userpass_delete'
-    - assert: { that: "{{vault_userpass_delete.changed}} == True" }
-    - assert: { that: "{{vault_userpass_delete.rc}} == 0" }
+    - assert: { that: "vault_userpass_delete is changed" }
+    - assert: { that: "vault_userpass_delete.rc == 0" }
 
     - template:
         src: "{{playbook_dir}}/templates/userpassenv.sh.j2"

--- a/functional/test_userpass_idempotent.yml
+++ b/functional/test_userpass_idempotent.yml
@@ -18,8 +18,8 @@
         policies: bob
       register: hashivault_userpass
       no_log: True
-    - assert: { that: "{{hashivault_userpass.changed}} == True" }
-    - assert: { that: "{{hashivault_userpass.rc}} == 0" }
+    - assert: { that: "hashivault_userpass is changed" }
+    - assert: { that: "hashivault_userpass.rc == 0" }
 
     - name: Set token_bound_cidr for userpass
       hashivault_userpass:
@@ -28,8 +28,8 @@
         policies: "default"
         token_bound_cidrs: "127.0.0.1"
       register: 'hashivault_userpass_token_bound_cidr'
-    - assert: { that: "{{hashivault_userpass_token_bound_cidr.changed}} == True" }
-    - assert: { that: "{{hashivault_userpass_token_bound_cidr.rc}} == 0" }
+    - assert: { that: "hashivault_userpass_token_bound_cidr is changed" }
+    - assert: { that: "hashivault_userpass_token_bound_cidr.rc == 0" }
 
     - name: Set token_bound_cidr for userpass (idempotent)
       hashivault_userpass:
@@ -38,5 +38,5 @@
         policies: "default"
         token_bound_cidrs: "127.0.0.1"
       register: 'hashivault_userpass_token_bound_cidr'
-    - assert: { that: "{{hashivault_userpass_token_bound_cidr.changed}} == False" }
-    - assert: { that: "{{hashivault_userpass_token_bound_cidr.rc}} == 0" }
+    - assert: { that: "hashivault_userpass_token_bound_cidr is not changed" }
+    - assert: { that: "hashivault_userpass_token_bound_cidr.rc == 0" }

--- a/functional/test_userpass_no_pass.yml
+++ b/functional/test_userpass_no_pass.yml
@@ -43,8 +43,8 @@
         policies: ["policy-bob"]
       register: hashivault_userpass
       no_log: True
-    - assert: { that: "{{hashivault_userpass.changed}} == True" }
-    - assert: { that: "{{hashivault_userpass.rc}} == 0" }
+    - assert: { that: "hashivault_userpass is changed" }
+    - assert: { that: "hashivault_userpass.rc == 0" }
 
     - name: Create token
       hashivault_token_create:
@@ -54,8 +54,8 @@
         policies: ["policy-bob"]
         password: "{{userpass}}"
       register: 'hashivault_userpass_update_no_pass_token'
-    - assert: { that: "{{hashivault_userpass_update_no_pass_token.changed}} == True" }
-    - assert: { that: "{{hashivault_userpass_update_no_pass_token.rc}} == 0" }
+    - assert: { that: "hashivault_userpass_update_no_pass_token is changed" }
+    - assert: { that: "hashivault_userpass_update_no_pass_token.rc == 0" }
 
     - name: Change policies without pass
       hashivault_userpass:
@@ -63,8 +63,8 @@
         password: ""
         policies: ["policy-bob", "default"]
       register: 'hashivault_userpass_update_no_pass'
-    - assert: { that: "{{hashivault_userpass_update_no_pass.changed}} == True" }
-    - assert: { that: "{{hashivault_userpass_update_no_pass.rc}} == 0" }
+    - assert: { that: "hashivault_userpass_update_no_pass is changed" }
+    - assert: { that: "hashivault_userpass_update_no_pass.rc == 0" }
 
     - name: Set cidr without pass is not possible
       hashivault_userpass:
@@ -75,9 +75,9 @@
       register: 'hashivault_userpass_update_no_pass_err'
     - debug:
         var: hashivault_userpass_update_no_pass_err
-    - assert: { that: "{{hashivault_userpass_update_no_pass_err.changed}} == False" }
-    - assert: { that: "{{hashivault_userpass_update_no_pass_err.rc}} == 1" }
-    - assert: { that: "'token_bound_cidrs can only be changed if user_pass is specified and user_pass_update is True' == '{{hashivault_userpass_update_no_pass_err.msg}}'" }
+    - assert: { that: "hashivault_userpass_update_no_pass_err is not changed" }
+    - assert: { that: "hashivault_userpass_update_no_pass_err.rc == 1" }
+    - assert: { that: "'token_bound_cidrs can only be changed if user_pass is specified and user_pass_update is True' == hashivault_userpass_update_no_pass_err.msg" }
 
     - name: Create token with updated user
       hashivault_token_create:
@@ -87,5 +87,5 @@
         policies: ["policy-bob"]
         password: "{{userpass}}"
       register: 'hashivault_userpass_update_no_pass_token'
-    - assert: { that: "{{hashivault_userpass_update_no_pass_token.changed}} == True" }
-    - assert: { that: "{{hashivault_userpass_update_no_pass_token.rc}} == 0" }
+    - assert: { that: "hashivault_userpass_update_no_pass_token is changed" }
+    - assert: { that: "hashivault_userpass_update_no_pass_token.rc == 0" }

--- a/functional/test_userpass_no_policy.yml
+++ b/functional/test_userpass_no_policy.yml
@@ -52,5 +52,5 @@
         password: ""
         policies: ["policy-bob", "default"]
       register: 'hashivault_userpass_update_policies'
-    - assert: { that: "{{hashivault_userpass_update_policies.changed}} == True" }
-    - assert: { that: "{{hashivault_userpass_update_policies.rc}} == 0" }
+    - assert: { that: "hashivault_userpass_update_policies is changed" }
+    - assert: { that: "hashivault_userpass_update_policies.rc == 0" }

--- a/functional/test_write.yml
+++ b/functional/test_write.yml
@@ -35,9 +35,9 @@
             foo: 'foe'
             fie: 'fum'
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/{{name_root}} written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret secret/' + name_root + ' written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Write again no update verify changed
       hashivault_write:
@@ -46,9 +46,9 @@
           foo: 'foe'
           fie: 'fum'
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/{{name_root}} written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret secret/' + name_root + ' written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update again and verify no change
       hashivault_write:
@@ -58,8 +58,8 @@
           foo: 'foe'
           fie: 'fum'
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update new value and detect change
       hashivault_write:
@@ -69,9 +69,9 @@
           foo: 'new'
           fie: 'fum'
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/{{name_root}} written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret secret/' + name_root + ' written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update a brand new secret in folder
       hashivault_write:
@@ -80,17 +80,17 @@
         data:
           height: tall
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/{{name_folder}} written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret secret/' + name_folder + ' written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Write secret dictionary
       hashivault_write:
         update: True
         secret: '{{name_dict}}'
         data: "{{ dict_value }}"
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update again secret dictionary and verify no change
       hashivault_write:
@@ -98,20 +98,20 @@
         secret: '{{name_dict}}'
         data: "{{ dict_value }}"
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update new value in dictionary and detect change
       hashivault_write:
         update: True
         secret: '{{name_dict}}'
-        data: 
+        data:
           foo: 'bar'
           baz: 'stuff'
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/{{name_dict}} written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret secret/' + name_dict + ' written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Write array type secret
       hashivault_write:
@@ -126,8 +126,8 @@
         data:
           value: "{{ array_of_dicts_value }}"
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update again array of dicts secret and verify no change
       hashivault_write:
@@ -136,8 +136,8 @@
         data:
           value: "{{ array_of_dicts_value }}"
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Update new value in array of dicts and detect change
       hashivault_write:
@@ -149,9 +149,9 @@
            - name: item-two
            - name: item-new
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "'{{vault_write.msg}}' == 'Secret secret/{{name_array_of_dicts}} written'" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.msg == 'Secret secret/' + name_array_of_dicts + ' written'" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Initial ttl values
       hashivault_write:
@@ -161,7 +161,7 @@
           ttl:      36000s
           max_ttl: 480s
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
+    - assert: { that: "vault_write is changed" }
 
     - name: Update minute ttl secret
       hashivault_write:
@@ -170,7 +170,7 @@
         data:
           ttl:      600m
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update hour ttl secret
       hashivault_write:
@@ -179,7 +179,7 @@
         data:
           ttl:      10h
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update second ttl secret
       hashivault_write:
@@ -188,7 +188,7 @@
         data:
           ttl:      36000s
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update second ttl secret no s
       hashivault_write:
@@ -197,7 +197,7 @@
         data:
           ttl:      36000
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
+    - assert: { that: "vault_write is not changed" }
 
     - name: Update second ttl secret new value
       hashivault_write:
@@ -206,7 +206,7 @@
         data:
           ttl:      36001s
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
+    - assert: { that: "vault_write is changed" }
 
     - hashivault_delete:
         secret: '{{namespace}}no_log'
@@ -223,8 +223,8 @@
           false: False
           true: True
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == True" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is changed" }
+    - assert: { that: "vault_write.rc == 0" }
 
     - name: Write a secret to mess up no_log again
       hashivault_write:
@@ -238,5 +238,5 @@
           false: False
           true: True
       register: vault_write
-    - assert: { that: "{{vault_write.changed}} == False" }
-    - assert: { that: "{{vault_write.rc}} == 0" }
+    - assert: { that: "vault_write is not changed" }
+    - assert: { that: "vault_write.rc == 0" }

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     py_modules=py_files,
     packages=files,
     install_requires=[
-        'ansible>=5.0.0',
+        'ansible-core>=2.12.0',
         'hvac>=1.2.1',
         'requests',
     ],


### PR DESCRIPTION
This is a tentative fix for https://github.com/TerryHowe/ansible-modules-hashivault/issues/455, just seeing if the CI is happy with it.