### PR TITLE
Shebang replacement

### DIFF
--- a/ansible/modules/hashivault/hashivault_approle_role.py
+++ b/ansible/modules/hashivault/hashivault_approle_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_approle_role_get.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_approle_role_id.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_id.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_approle_role_list.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_approle_role_secret.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_secret.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client

--- a/ansible/modules/hashivault/hashivault_approle_role_secret_accessor_get.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_secret_accessor_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_approle_role_secret_get.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_secret_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client

--- a/ansible/modules/hashivault/hashivault_approle_role_secret_list.py
+++ b/ansible/modules/hashivault/hashivault_approle_role_secret_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from hvac.exceptions import InvalidPath
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client

--- a/ansible/modules/hashivault/hashivault_audit.py
+++ b/ansible/modules/hashivault/hashivault_audit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_audit_list.py
+++ b/ansible/modules/hashivault/hashivault_audit_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_auth_ldap.py
+++ b/ansible/modules/hashivault/hashivault_auth_ldap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_auth_list.py
+++ b/ansible/modules/hashivault/hashivault_auth_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_auth_method.py
+++ b/ansible/modules/hashivault/hashivault_auth_method.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import is_state_changed
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client

--- a/ansible/modules/hashivault/hashivault_aws_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_aws_auth_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_aws_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_aws_auth_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_azure_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_azure_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_auth_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_azure_secret_engine_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_cluster_status.py
+++ b/ansible/modules/hashivault/hashivault_cluster_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_consul_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_consul_secret_engine_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_consul_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_consul_secret_engine_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_db_secret_engine_role.py
+++ b/ansible/modules/hashivault/hashivault_db_secret_engine_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_delete.py
+++ b/ansible/modules/hashivault/hashivault_delete.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from hvac.exceptions import InvalidPath
 
 from ansible.module_utils.hashivault import hashivault_argspec

--- a/ansible/modules/hashivault/hashivault_generate_root.py
+++ b/ansible/modules/hashivault/hashivault_generate_root.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init
 from ansible.module_utils.hashivault import hashiwrapper

--- a/ansible/modules/hashivault/hashivault_generate_root_cancel.py
+++ b/ansible/modules/hashivault/hashivault_generate_root_cancel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_generate_root_init.py
+++ b/ansible/modules/hashivault/hashivault_generate_root_init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_generate_root_status.py
+++ b/ansible/modules/hashivault/hashivault_generate_root_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_identity_entity.py
+++ b/ansible/modules/hashivault/hashivault_identity_entity.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_identity_entity_alias.py
+++ b/ansible/modules/hashivault/hashivault_identity_entity_alias.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_identity_group.py
+++ b/ansible/modules/hashivault/hashivault_identity_group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_identity_group_alias.py
+++ b/ansible/modules/hashivault/hashivault_identity_group_alias.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_identity_group_alias_list.py
+++ b/ansible/modules/hashivault/hashivault_identity_group_alias_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_init.py
+++ b/ansible/modules/hashivault/hashivault_init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_k8s_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_k8s_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_ldap_group.py
+++ b/ansible/modules/hashivault/hashivault_ldap_group.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_leader.py
+++ b/ansible/modules/hashivault/hashivault_leader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_list.py
+++ b/ansible/modules/hashivault/hashivault_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from hvac.exceptions import InvalidPath
 
 from ansible.module_utils.hashivault import hashivault_argspec

--- a/ansible/modules/hashivault/hashivault_namespace.py
+++ b/ansible/modules/hashivault/hashivault_namespace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_method_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_oidc_auth_role.py
+++ b/ansible/modules/hashivault/hashivault_oidc_auth_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_ca.py
+++ b/ansible/modules/hashivault/hashivault_pki_ca.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_ca_set.py
+++ b/ansible/modules/hashivault/hashivault_pki_ca_set.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_cert_get.py
+++ b/ansible/modules/hashivault/hashivault_pki_cert_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_cert_issue.py
+++ b/ansible/modules/hashivault/hashivault_pki_cert_issue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_cert_list.py
+++ b/ansible/modules/hashivault/hashivault_pki_cert_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_cert_revoke.py
+++ b/ansible/modules/hashivault/hashivault_pki_cert_revoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_cert_sign.py
+++ b/ansible/modules/hashivault/hashivault_pki_cert_sign.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_crl.py
+++ b/ansible/modules/hashivault/hashivault_pki_crl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_crl_get.py
+++ b/ansible/modules/hashivault/hashivault_pki_crl_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_crl_rotate.py
+++ b/ansible/modules/hashivault/hashivault_pki_crl_rotate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_role.py
+++ b/ansible/modules/hashivault/hashivault_pki_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_role_get.py
+++ b/ansible/modules/hashivault/hashivault_pki_role_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_role_list.py
+++ b/ansible/modules/hashivault/hashivault_pki_role_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_set_signed.py
+++ b/ansible/modules/hashivault/hashivault_pki_set_signed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_tidy.py
+++ b/ansible/modules/hashivault/hashivault_pki_tidy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_url.py
+++ b/ansible/modules/hashivault/hashivault_pki_url.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_pki_url_get.py
+++ b/ansible/modules/hashivault/hashivault_pki_url_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_policy.py
+++ b/ansible/modules/hashivault/hashivault_policy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_policy_get.py
+++ b/ansible/modules/hashivault/hashivault_policy_get.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_policy_list.py
+++ b/ansible/modules/hashivault/hashivault_policy_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_read.py
+++ b/ansible/modules/hashivault/hashivault_read.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_read_to_file.py
+++ b/ansible/modules/hashivault/hashivault_read_to_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
 DOCUMENTATION = '''
 ---

--- a/ansible/modules/hashivault/hashivault_rekey.py
+++ b/ansible/modules/hashivault/hashivault_rekey.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_rekey_cancel.py
+++ b/ansible/modules/hashivault/hashivault_rekey_cancel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_rekey_init.py
+++ b/ansible/modules/hashivault/hashivault_rekey_init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_rekey_status.py
+++ b/ansible/modules/hashivault/hashivault_rekey_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_rekey_verify.py
+++ b/ansible/modules/hashivault/hashivault_rekey_verify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_seal.py
+++ b/ansible/modules/hashivault/hashivault_seal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_secret.py
+++ b/ansible/modules/hashivault/hashivault_secret.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from hvac.exceptions import InvalidPath
 
 from ansible.module_utils.hashivault import is_state_changed

--- a/ansible/modules/hashivault/hashivault_secret_engine.py
+++ b/ansible/modules/hashivault/hashivault_secret_engine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import is_state_changed
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client

--- a/ansible/modules/hashivault/hashivault_secret_list.py
+++ b/ansible/modules/hashivault/hashivault_secret_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_ssh_role.py
+++ b/ansible/modules/hashivault/hashivault_ssh_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 import copy
 

--- a/ansible/modules/hashivault/hashivault_ssh_role_list.py
+++ b/ansible/modules/hashivault/hashivault_ssh_role_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_status.py
+++ b/ansible/modules/hashivault/hashivault_status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_token_create.py
+++ b/ansible/modules/hashivault/hashivault_token_create.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_token_lookup.py
+++ b/ansible/modules/hashivault/hashivault_token_lookup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client

--- a/ansible/modules/hashivault/hashivault_token_renew.py
+++ b/ansible/modules/hashivault/hashivault_token_renew.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_token_revoke.py
+++ b/ansible/modules/hashivault/hashivault_token_revoke.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_token_role.py
+++ b/ansible/modules/hashivault/hashivault_token_role.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 import copy
 

--- a/ansible/modules/hashivault/hashivault_token_role_list.py
+++ b/ansible/modules/hashivault/hashivault_token_role_list.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_unseal.py
+++ b/ansible/modules/hashivault/hashivault_unseal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_userpass.py
+++ b/ansible/modules/hashivault/hashivault_userpass.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from ansible.module_utils.hashivault import hashivault_argspec
 from ansible.module_utils.hashivault import hashivault_auth_client
 from ansible.module_utils.hashivault import hashivault_init

--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 from hvac.exceptions import InvalidPath
 
 from ansible.module_utils.hashivault import is_state_changed

--- a/ansible/modules/hashivault/hashivault_write_from_file.py
+++ b/ansible/modules/hashivault/hashivault_write_from_file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 ANSIBLE_METADATA = {'status': ['stableinterface'], 'supported_by': 'community', 'version': '1.1'}
 DOCUMENTATION = '''
 ---

--- a/ansible/plugins/lookup/hashivault.py
+++ b/ansible/plugins/lookup/hashivault.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # Vault Lookup Plugin
 #


### PR DESCRIPTION
This PR will fix this [issue](https://github.com/TerryHowe/ansible-modules-hashivault/issues/412).

Pretty good explanation of root of this issue is [here](https://github.com/ansible/ansible/issues/78809) especially [this](https://github.com/ansible/ansible/issues/78809#issuecomment-1251489654) comment.

Rationale behind deleting shebang instead of changing it to `#!/usr/bin/python`:

- it will default to `#!/usr/bin/python` anyway.
- module files aren't executed so no shebang isn't needed, and modules should be treated more like python libraries not executables.
- if any change to interpreter is needed it should be done by using `ansible_python_interpreter` variable, which [this PR](https://github.com/ansible/ansible/pull/76677) made possible.

Any contribution and comment is welcomed. 