### PR TITLE
chore: Use write_data method

### DIFF
--- a/ansible/modules/hashivault/hashivault_write.py
+++ b/ansible/modules/hashivault/hashivault_write.py
@@ -133,7 +133,7 @@ def hashivault_write(module):
                     returned_data = client.secrets.kv.v2.create_or_update_secret(mount_point=mount_point, cas=cas,
                                                                                  path=secret, secret=write_data)
                 else:
-                    returned_data = client.write(secret_path, **write_data)
+                    returned_data = client.write_data(secret_path, data=write_data)
                 if returned_data:
                     from requests.models import Response
                     if isinstance(returned_data, Response):


### PR DESCRIPTION
The write_data method allows the user to store data named `path` and `wrap_ttl`