### PR TITLE
add disable_local_ca_jwt param in k8s auth config

### DIFF
--- a/ansible/modules/hashivault/hashivault_k8s_auth_config.py
+++ b/ansible/modules/hashivault/hashivault_k8s_auth_config.py
@@ -37,6 +37,9 @@ options:
         description:
             - Optional JWT issuer. If no issuer is specified, then this plugin will use kubernetes.io/serviceaccount as
               the default issuer (Available in hvac 0.10.2).
+    disable_local_ca_jwt:
+        description:
+            - Disable defaulting to the local CA cert and service account JWT when running in a Kubernetes pod.
 extends_documentation_fragment: hashivault
 '''
 EXAMPLES = '''
@@ -57,6 +60,7 @@ def main():
     argspec['kubernetes_ca_cert'] = dict(required=False, type='str', default=None)
     argspec['pem_keys'] = dict(required=False, type='list', default=None)
     argspec['issuer'] = dict(required=False, type='str', default=None)
+    argspec['disable_local_ca_jwt'] = dict(required=False, type='bool', default=False)
     required_together = [['kubernetes_host', 'kubernetes_ca_cert']]
 
     module = hashivault_init(argspec, supports_check_mode=True, required_together=required_together)
@@ -78,6 +82,7 @@ def hashivault_k8s_auth_config(module):
     desired_state['token_reviewer_jwt'] = params.get('token_reviewer_jwt')
     desired_state['kubernetes_ca_cert'] = params.get('kubernetes_ca_cert')
     desired_state['pem_keys'] = params.get('pem_keys')
+    desired_state['disable_local_ca_jwt'] = params.get('disable_local_ca_jwt')
     if params.get('issuer'):
         desired_state['issuer'] = params.get('issuer')
     desired_state['mount_point'] = mount_point


### PR DESCRIPTION
Hello,
this change allows setting the disable_local_ca_jwt flag in the k8s auth config. It's required when vault is running in a k8s cluster but you want to use the request token to do the full auth.
official doc for that flag is here https://developer.hashicorp.com/vault/api-docs/auth/kubernetes#disable_local_ca_jwt